### PR TITLE
Fix: #254 avoid resetting index in multi-process HashingEncoder

### DIFF
--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -266,7 +266,7 @@ class HashingEncoder(BaseEstimator, TransformerMixin):
             for part_index in sorted(list_data):
                 sort_data.append(list_data[part_index])
             if sort_data:
-                data = pd.concat(sort_data, ignore_index=True)
+                data = pd.concat(sort_data)
         # Check if is_return_df
         if self.return_df or override_return_df:
             return data

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+
+import pandas as pd
+from pandas.testing import assert_frame_equal, assert_index_equal
+
+import category_encoders as encoders
+
+
+class TestHashingEncoder(TestCase):
+    def test_must_not_reset_index(self):
+        columns = ['column1', 'column2', 'column3', 'column4']
+        df = pd.DataFrame([[i, i, i, i] for i in range(10)], columns=columns)
+        df = df.iloc[2:8, :]
+        target_columns = ['column1', 'column2', 'column3']
+
+        single_process_encoder = encoders.HashingEncoder(max_process=1, cols=target_columns)
+        single_process_encoder.fit(df, None)
+        df_encoded_single_process = single_process_encoder.transform(df)
+        assert_index_equal(df.index, df_encoded_single_process.index)
+        assert df.shape[0] == pd.concat([df, df_encoded_single_process], axis=1).shape[0]
+
+        multi_process_encoder = encoders.HashingEncoder(cols=target_columns)
+        multi_process_encoder.fit(df, None)
+        df_encoded_multi_process = multi_process_encoder.transform(df)
+        assert_index_equal(df.index, df_encoded_multi_process.index)
+        assert df.shape[0] == pd.concat([df, df_encoded_multi_process], axis=1).shape[0]
+
+        assert_frame_equal(df_encoded_single_process, df_encoded_multi_process)


### PR DESCRIPTION
Fix: #254 

## Proposed Changes

  - Disable ignore_index option
    - From what I see, it doesn't seem necessary to specify ignore_index, so I suggest not to do so.
  - add test code