### PR TITLE
is_categorical deprecated

### DIFF
--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -18,7 +18,7 @@ def convert_cols_to_list(cols):
         return list(cols)
     elif isinstance(cols, tuple):
         return list(cols)
-    elif pd.api.types.is_categorical(cols):
+    elif pd.api.types.is_categorical_dtype(cols):
         return cols.astype(object).tolist()
 
     return cols


### PR DESCRIPTION
Getting FutureWarning that is_categorical is deprecated. See pandas-dev/pandas#33385

## Proposed Changes

  - Change `is_categorical()` to `is_categorical_dtype()` 
  -
  -