### PR TITLE
Adjusted method ordinal_encoding

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -319,8 +319,8 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
             for col in cols:
 
                 nan_identity = np.nan
-
-                categories = X[col].unique().tolist()
+                
+                categories = list(X[col].unique())
                 if util.is_category(X[col].dtype):
                     # Avoid using pandas category dtype meta-data if possible, see #235, #238.
                     if X[col].dtype.ordered:


### PR DESCRIPTION
The problem occurs because the dataframe contains `dtype='string'` parameter. With this, the `unique()` method returns `StringArray` object, not np array.

Fixes #270

## Proposed Changes

  - Instead of using `tolist` method, it was included the `list` call outside.