### PR TITLE
Fix BaseNEncoder number of output columns

### DIFF
--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -12,6 +12,27 @@ import warnings
 __author__ = 'willmcginnis'
 
 
+def _ceillogint(n, base):
+    """
+    Returns ceil(log(n, base)) for integers n and base.
+
+    Uses integer math, so the result is not subject to floating point rounding errors.
+
+    base must be >= 2 and n must be >= 1.
+    """
+    if base < 2:
+        raise ValueError('base must be >= 2')
+    if n < 1:
+        raise ValueError('n must be >= 1')
+
+    n -= 1
+    ret = 0
+    while n > 0:
+        ret += 1
+        n //= base
+    return ret
+
+
 class BaseNEncoder(BaseEstimator, TransformerMixin):
     """Base-N encoder encodes the categories into arrays of their base-N representation.  A base of 1 is equivalent to
     one-hot encoding (not really base-1, but useful), a base of 2 is equivalent to binary encoding. N=number of actual
@@ -296,7 +317,7 @@ class BaseNEncoder(BaseEstimator, TransformerMixin):
         if self.base == 1:
             digits = len(values) + 1
         else:
-            digits = int(np.ceil(math.log(len(values), self.base))) + 1
+            digits = _ceillogint(len(values) + 1, self.base)
 
         return digits
 

--- a/tests/test_glmm.py
+++ b/tests/test_glmm.py
@@ -5,7 +5,7 @@ import tests.helpers as th
 
 # data definitions
 X = th.create_dataset(n_rows=100)
-np_y = np.random.randn(100) > 0.5
+np_y = np.random.default_rng(42).standard_normal(100) > 0.5
 
 class TestGLMMEncoder(TestCase):
     def test_continuous(self):


### PR DESCRIPTION
BaseNEncoder encoder used an incorrect formula for calculating the number of required bits in the output. If there are `nvals` distinct values and we reserve one encoding to represent "missing or unknown", then the correct number of bits is `ceil(log(nvals + 1, base))`. However, the code was previously using the formula `ceil(log(nvals, base)) + 1`.

Fixes https://github.com/scikit-learn-contrib/category_encoders/issues/264

## Proposed Changes
  - Change the formula to `ceil(log(nvals + 1, base))`.
  - Switch the formula to use integer math so we don't have to worry about floating point rounding errors.
  - Add a test.
  - Fix a non-deterministic test.