### PR TITLE
Fix bad WOE scores.

### DIFF
--- a/category_encoders/woe.py
+++ b/category_encoders/woe.py
@@ -253,7 +253,7 @@ class WOEEncoder(BaseEstimator, util.TransformerWithTargetMixin):
             col = switch.get('col')
             values = switch.get('mapping')
             # Calculate sum and count of the target for each unique value in the feature col
-            stats = y.groupby(X[col]).agg(['sum', 'count'])  # Count of x_{i,+} and x_i
+            stats = y.groupby(X[col].to_numpy()).agg(['sum', 'count'])  # Count of x_{i,+} and x_i
 
             # Create a new column with regularized WOE.
             # Regularization helps to avoid division by zero.


### PR DESCRIPTION
I found that the WOEEncoder was not giving the right scores, and it was because of the the agg stats not being correct from pandas. The stats did work if we grouped by a numpy array instead of a pandas col though. So that's the fix offered here.

Fixes #

## Proposed Changes

  -
  -
  -