### PR TITLE
single row hashing encoder transform error

### DIFF
--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -241,6 +241,9 @@ class HashingEncoder(BaseEstimator, TransformerMixin):
 
         if self.auto_sample:
             self.max_sample = int(self.data_lines / self.max_process)
+
+            if self.max_sample == 0:
+                self.max_sample = 1
         if self.max_process == 1:
             self.require_data(self, data_lock, new_start, done_index, hashing_parts, cols=self.cols, process_index=1)
         else:

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -26,3 +26,19 @@ class TestHashingEncoder(TestCase):
         assert df.shape[0] == pd.concat([df, df_encoded_multi_process], axis=1).shape[0]
 
         assert_frame_equal(df_encoded_single_process, df_encoded_multi_process)
+
+    def test_transform_works_with_single_row_df(self):
+        columns = ['column1', 'column2', 'column3', 'column4']
+        df = pd.DataFrame([[i, i, i, i] for i in range(10)], columns=columns)
+        df = df.iloc[2:8, :]
+        target_columns = ['column1', 'column2', 'column3']
+
+        multi_process_encoder = encoders.HashingEncoder(cols=target_columns)
+        multi_process_encoder.fit(df, None)
+        df_encoded_multi_process = multi_process_encoder.transform(df.sample(1))
+        
+        assert (multi_process_encoder.n_components +
+                len(list(set(columns) -
+                         set(target_columns))
+                   ) == df_encoded_multi_process.shape[1]
+               )


### PR DESCRIPTION
When using the transform for a small dataset the hashing encoder hangs because self.max_sample == 0. This becomes a problem when slicing the dataset and the multiprocessing part of hashing encoder hangs indefinitely. The test shows this problem and this simple if fixes it.

First PR, please forgive me if I'm out of guidelines. I've reviewed the guidelines file, but anyway I might have missed something