### PR TITLE
Fix ohe nan col

### DIFF
--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -142,15 +142,12 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
             if X[self.cols].isnull().any().any():
                 raise ValueError('Columns to be encoded can not contain null')
 
-        # TODO: when these are settled, make the code sleeker
-        if self.handle_missing == 'error':
-            oe_missing_strat = 'error'
-        elif self.handle_missing == 'return_nan':
-            oe_missing_strat = 'return_nan'
-        elif self.handle_missing == 'value':
-            oe_missing_strat = 'value'
-        elif self.handle_missing == 'indicator':
-            oe_missing_strat = 'return_nan'
+        oe_missing_strat = {
+            'error': 'error',
+            'return_nan': 'return_nan',
+            'value': 'value',
+            'indicator': 'return_nan',
+        }[self.handle_missing]
 
         self.ordinal_encoder = OrdinalEncoder(
             verbose=self.verbose,
@@ -194,12 +191,12 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
             index = []
             new_columns = []
 
-            add_me_to_the_end = False
+            append_nan_to_index = False
             for cat_name, class_ in values.iteritems():
                 if pd.isna(cat_name) and self.handle_missing == 'return_nan':
                     # we don't want a mapping column if return_nan
                     # but do add the index to the end
-                    add_me_to_the_end = class_
+                    append_nan_to_index = class_
                     continue
                 if self.use_cat_names:
                     n_col_name = str(col) + '_%s' % (cat_name,)
@@ -221,8 +218,8 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
                 new_columns.append(n_col_name)
                 index.append(-1)
 
-            if add_me_to_the_end:
-                index.append(add_me_to_the_end)
+            if append_nan_to_index:
+                index.append(append_nan_to_index)
 
             base_matrix = np.eye(N=len(index), M=len(new_columns), dtype=int)
             base_df = pd.DataFrame(data=base_matrix, columns=new_columns, index=index)

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -238,16 +238,16 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
 
         """
 
-        if self.handle_missing == 'error':
-            if X[self.cols].isnull().any().any():
-                raise ValueError('Columns to be encoded can not contain null')
-
         if self._dim is None:
             raise ValueError(
                 'Must train encoder before it can be used to transform data.')
 
         # first check the type
         X = util.convert_input(X)
+
+        if self.handle_missing == 'error':
+            if X[self.cols].isnull().any().any():
+                raise ValueError('Columns to be encoded can not contain null')
 
         # then make sure that it is the right size
         if X.shape[1] != self._dim:

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -146,7 +146,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
             verbose=self.verbose,
             cols=self.cols,
             handle_unknown='value',
-            handle_missing='value'
+            handle_missing='error' if self.handle_missing == 'error' else 'value'
         )
         self.ordinal_encoder = self.ordinal_encoder.fit(X)
         self.mapping = self.generate_mapping()

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -27,13 +27,20 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         if True, category values will be included in the encoded column names. Since this can result in duplicate column names, duplicates are suffixed with '#' symbol until a unique name is generated.
         If False, category indices will be used instead of the category values.
     handle_unknown: str
-        options are 'error', 'return_nan', 'value', and 'indicator'. The default is 'value'. Warning: if indicator is used,
-        an extra column will be added in if the transform matrix has unknown categories.  This can cause
-        unexpected changes in dimension in some cases.
+        options are 'error', 'return_nan', 'value', and 'indicator'. The default is 'value'.
+
+        'error' will raise a `ValueError` at transform time if there are new categories.
+        'return_nan' will encode a new value as `np.nan` in every dummy column.
+        'value' will encode a new value as 0 in every dummy column.
+        'indicator' will add an additional dummy column (in both training and test data).
     handle_missing: str
-        options are 'error', 'return_nan', 'value', and 'indicator'. The default is 'value'. Warning: if indicator is used,
-        an extra column will be added in if the transform matrix has nan values.  This can cause
-        unexpected changes in dimension in some cases.
+        options are 'error', 'return_nan', 'value', and 'indicator'. The default is 'value'.
+
+        'error' will raise a `ValueError` if missings are encountered.
+        'return_nan' will encode a missing value as `np.nan` in every dummy column.
+        'value' will encode a missing value as 0 in every dummy column.
+        'indicator' will treat missingness as its own category, adding an additional dummy column
+        (whether there are missing values in the training set or not).
 
     Example
     -------

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -144,6 +144,21 @@ class TestOneHotEncoderTestCase(TestCase):
 
         pd.testing.assert_frame_equal(expected_result, result)
 
+    def test_HandleMissingError(self):
+        data_no_missing = ['A', 'B', 'B']
+        data_w_missing = [np.nan, 'B', 'B']
+        encoder = encoders.OneHotEncoder(handle_missing="error")
+
+        result = encoder.fit_transform(data_no_missing)
+        expected = [[1, 0],
+                    [0, 1],
+                    [0, 1]]
+        self.assertEqual(result.values.tolist(), expected)
+
+        self.assertRaisesRegex(ValueError, '.*null.*', encoder.transform, data_w_missing)
+
+        self.assertRaisesRegex(ValueError, '.*null.*', encoder.fit, data_w_missing)
+
     def test_HandleMissingIndicator_NanInTrain_ExpectAsColumn(self):
         train = ['A', 'B', np.nan]
 

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -159,6 +159,15 @@ class TestOneHotEncoderTestCase(TestCase):
 
         self.assertRaisesRegex(ValueError, '.*null.*', encoder.fit, data_w_missing)
 
+    def test_HandleMissingReturnNan(self):
+        train = pd.DataFrame({'x': ['A', np.nan, 'B']})
+        encoder = encoders.OneHotEncoder(handle_missing='return_nan', use_cat_names=True)
+        result = encoder.fit_transform(train)
+        pd.testing.assert_frame_equal(
+            result,
+            pd.DataFrame({'x_A': [1, np.nan, 0], 'x_B': [0, np.nan, 1]}),
+        )
+
     def test_HandleMissingIndicator_NanInTrain_ExpectAsColumn(self):
         train = ['A', 'B', np.nan]
 

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -194,13 +194,17 @@ class TestOneHotEncoderTestCase(TestCase):
         test = ['A', 'B', np.nan]
 
         encoder = encoders.OneHotEncoder(handle_missing='indicator', handle_unknown='value')
-        encoder.fit(train)
-        result = encoder.transform(test)
+        encoded_train = encoder.fit_transform(train)
+        encoded_test = encoder.transform(test)
 
-        expected = [[1, 0, 0],
-                    [0, 1, 0],
-                    [0, 0, 1]]
-        self.assertEqual(result.values.tolist(), expected)
+        expected_1 = [[1, 0, 0],
+                      [0, 1, 0]]
+        self.assertEqual(encoded_train.values.tolist(), expected_1)
+
+        expected_2 = [[1, 0, 0],
+                      [0, 1, 0],
+                      [0, 0, 1]]
+        self.assertEqual(encoded_test.values.tolist(), expected_2)
 
     def test_HandleUnknown_HaveNoUnknownInTrain_ExpectIndicatorInTest(self):
         train = ['A', 'B']


### PR DESCRIPTION
Fixes #295

## Proposed Changes

Prevents a column for missing values from being added in OneHotEncoder when handle_missing="error".  Does this by preventing the underlying OrdinalEncoder from producing the mapping NaN->-2, by setting _its_ handle_missing to "error" as well.

Also patches an incidental bug in OneHotEncoder.transform when handle_missing="error", when the input is not a frame.

Hacktoberfest?
