### PR TITLE
Fix pandas future warning for dropping invariants

### DIFF
--- a/category_encoders/backward_difference.py
+++ b/category_encoders/backward_difference.py
@@ -214,7 +214,7 @@ class BackwardDifferenceEncoder(BaseEstimator, TransformerMixin):
         X = self.backward_difference_coding(X, mapping=self.mapping)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/backward_difference.py
+++ b/category_encoders/backward_difference.py
@@ -214,8 +214,7 @@ class BackwardDifferenceEncoder(BaseEstimator, TransformerMixin):
         X = self.backward_difference_coding(X, mapping=self.mapping)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -253,8 +253,7 @@ class BaseNEncoder(BaseEstimator, TransformerMixin):
         X_out = self.basen_encode(X_out, cols=self.cols)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X_out.drop(col, 1, inplace=True)
+            X_out = X_out.drop(columns=self.drop_cols)
 
         # impute missing values only in the generated columns
         # generated_cols = util.get_generated_cols(X, X_out, self.cols)

--- a/category_encoders/cat_boost.py
+++ b/category_encoders/cat_boost.py
@@ -208,8 +208,7 @@ class CatBoostEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         )
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/cat_boost.py
+++ b/category_encoders/cat_boost.py
@@ -208,7 +208,7 @@ class CatBoostEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         )
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -218,7 +218,7 @@ class CountEncoder(BaseEstimator, TransformerMixin):
         X, _ = self._transform_count_encode(X, y)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -218,8 +218,7 @@ class CountEncoder(BaseEstimator, TransformerMixin):
         X, _ = self._transform_count_encode(X, y)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/glmm.py
+++ b/category_encoders/glmm.py
@@ -226,7 +226,7 @@ class GLMMEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/glmm.py
+++ b/category_encoders/glmm.py
@@ -226,8 +226,7 @@ class GLMMEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -308,8 +308,7 @@ class HashingEncoder(BaseEstimator, TransformerMixin):
         X = self.hashing_trick(X, hashing_method=self.hash_method, N=self.n_components, cols=self.cols)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -202,8 +202,7 @@ class HashingEncoder(BaseEstimator, TransformerMixin):
                 # Always get df and check it after merge all data parts
                 data_part = self.hashing_trick(X_in=data_part, hashing_method=self.hash_method, N=self.n_components, cols=self.cols)
                 if self.drop_invariant:
-                    for col in self.drop_cols:
-                        data_part.drop(col, 1, inplace=True)
+                    data_part = data_part.drop(columns=self.drop_cols)
                 part_index = int(math.ceil(end_index / self.max_sample))
                 hashing_parts.put({part_index: data_part})
                 if self.verbose == 5:

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -308,7 +308,7 @@ class HashingEncoder(BaseEstimator, TransformerMixin):
         X = self.hashing_trick(X, hashing_method=self.hash_method, N=self.n_components, cols=self.cols)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/helmert.py
+++ b/category_encoders/helmert.py
@@ -211,7 +211,7 @@ class HelmertEncoder(BaseEstimator, TransformerMixin):
         X = self.helmert_coding(X, mapping=self.mapping)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/helmert.py
+++ b/category_encoders/helmert.py
@@ -211,8 +211,7 @@ class HelmertEncoder(BaseEstimator, TransformerMixin):
         X = self.helmert_coding(X, mapping=self.mapping)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/james_stein.py
+++ b/category_encoders/james_stein.py
@@ -289,7 +289,7 @@ class JamesSteinEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/james_stein.py
+++ b/category_encoders/james_stein.py
@@ -289,8 +289,7 @@ class JamesSteinEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -195,8 +195,7 @@ class LeaveOneOutEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         )
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -195,7 +195,7 @@ class LeaveOneOutEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         )
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/m_estimate.py
+++ b/category_encoders/m_estimate.py
@@ -221,7 +221,7 @@ class MEstimateEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/m_estimate.py
+++ b/category_encoders/m_estimate.py
@@ -221,8 +221,7 @@ class MEstimateEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -289,8 +289,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         X = self.get_dummies(X)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -289,7 +289,7 @@ class OneHotEncoder(BaseEstimator, TransformerMixin):
         X = self.get_dummies(X)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -210,7 +210,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
 
         if self.drop_invariant:
             for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+                )
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -209,8 +209,7 @@ class OrdinalEncoder(BaseEstimator, TransformerMixin):
         )
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                )
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/polynomial.py
+++ b/category_encoders/polynomial.py
@@ -212,8 +212,7 @@ class PolynomialEncoder(BaseEstimator, TransformerMixin):
         X = self.polynomial_coding(X, self.mapping)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/polynomial.py
+++ b/category_encoders/polynomial.py
@@ -212,7 +212,7 @@ class PolynomialEncoder(BaseEstimator, TransformerMixin):
         X = self.polynomial_coding(X, self.mapping)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/quantile_encoder.py
+++ b/category_encoders/quantile_encoder.py
@@ -241,7 +241,7 @@ class QuantileEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         X = self.quantile_encode(X)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/quantile_encoder.py
+++ b/category_encoders/quantile_encoder.py
@@ -241,8 +241,7 @@ class QuantileEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         X = self.quantile_encode(X)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/sum_coding.py
+++ b/category_encoders/sum_coding.py
@@ -212,8 +212,7 @@ class SumEncoder(BaseEstimator, TransformerMixin):
         X = self.sum_coding(X, mapping=self.mapping)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/sum_coding.py
+++ b/category_encoders/sum_coding.py
@@ -212,7 +212,7 @@ class SumEncoder(BaseEstimator, TransformerMixin):
         X = self.sum_coding(X, mapping=self.mapping)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -227,7 +227,7 @@ class TargetEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         X = self.target_encode(X)
 
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -227,8 +227,7 @@ class TargetEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         X = self.target_encode(X)
 
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/woe.py
+++ b/category_encoders/woe.py
@@ -219,7 +219,7 @@ class WOEEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            X = X.drop(columns=colself.drop_cols)
+            X = X.drop(columns=self.drop_cols)
 
         if self.return_df or override_return_df:
             return X

--- a/category_encoders/woe.py
+++ b/category_encoders/woe.py
@@ -219,8 +219,7 @@ class WOEEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         # Postprocessing
         # Note: We should not even convert these columns.
         if self.drop_invariant:
-            for col in self.drop_cols:
-                X.drop(col, 1, inplace=True)
+            X = X.drop(columns=colself.drop_cols)
 
         if self.return_df or override_return_df:
             return X


### PR DESCRIPTION
When I use `drop_invariant=True`, I get a `FutureWarning` because `df.drop` is switching to named kwargs only. This fixes it.

It should also be substantially more performant as the DF is only modified once.