### PR TITLE
Avoid `DeprecationWarning` of scipy

### DIFF
--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import numpy as np
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 __author__ = 'willmcginnis'
 


### PR DESCRIPTION
After [scipy@1.8.0](https://github.com/scipy/scipy/blob/maintenance/1.8.x/scipy/sparse/csr.py), the `scipy.sparse.csr` namespace is deprecated. So `category_encoders` asserts the DeprecationWarning when it depends scipy:^1.8.0;
``` shell
$ python -Wd 
Python 3.10.4 (main, Apr  6 2022, 00:48:19) [GCC 7.3.1 20180712 (Red Hat 7.3.1-13)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import category_encoders
(omitted)/python3.10/site-packages/category_encoders/utils.py:5: DeprecationWarning: Please use `csr_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.csr` namespace is deprecated.
  from scipy.sparse.csr import csr_matrix
>>> category_encoders.__version__
'2.4.0'
>>> import scipy
>>> scipy.__version__
'1.8.0'
```

We need to use `csr_matrix` from the `scipy.sparse` namespace. This namespace exists at least [scipy@1.0.0](https://github.com/scipy/scipy/blob/maintenance/1.0.x/scipy/sparse/__init__.py) until now ([docs](https://docs.scipy.org/doc/scipy-1.0.0/reference/sparse.html))

## Proposed Changes

  - To avoid the DeprecationWarning, we import `csr_matrix` from the `scipy.sparse` instead of the `scipy.sparse.csr` which is deprecated.

※ This is my first pull request, so I apologize if there are any problems. I would appreciate it if you could check it.