### PR TITLE
Include dict comprehension

### DIFF
--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -128,7 +128,7 @@ class LeaveOneOutEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
         codes[codes == -1] = len(categories)
         categories = np.append(categories, np.nan)
 
-        return_map = pd.Series(dict([(code, category) for code, category in enumerate(categories)]))
+        return_map = pd.Series({code: category for code, category in enumerate(categories)})
 
         result = y.groupby(codes).agg(['sum', 'count'])
         return result.rename(return_map)


### PR DESCRIPTION
## Proposed Changes

Replace `dict` constructor with `dict` comprehension In `category_encoders/leave_one_out.py`, because it is much faster.