### PR TITLE
fix: Broken inverse_transform for OrdinalEncoder when custom mapping …

### DIFF
--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -168,7 +168,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
         for switch in self.mapping:
             column_mapping = switch.get('mapping')
-            inverse = pd.Series(data=column_mapping.index, index=column_mapping.values)
+            inverse = pd.Series(data=column_mapping.keys(), index=column_mapping.values())
             X[switch.get('col')] = X[switch.get('col')].map(inverse).astype(switch.get('data_type'))
 
         return X if self.return_df else X.values


### PR DESCRIPTION
This PR fixes issue #202. It then allows for inverse transform to be performed with custom dict.

## Proposed Changes

The changes are minor and modify line 171 by implementing comment https://github.com/scikit-learn-contrib/category_encoders/issues/202#issuecomment-946159286