### PR TITLE
Improve hash-encoder performance - avoid unecessary Series construction

### DIFF
--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -306,14 +306,14 @@ class HashingEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                     else:
                         hasher.update(bytes(str(val), 'utf-8'))
                     tmp[int(hasher.hexdigest(), 16) % N] += 1
-            return pd.Series(tmp, index=new_cols)
+            return tmp
 
         new_cols = [f'col_{d}' for d in range(N)]
 
         X_cat = X.loc[:, cols]
         X_num = X.loc[:, [x for x in X.columns.values if x not in cols]]
 
-        X_cat = X_cat.apply(hash_fn, axis=1)
+        X_cat = X_cat.apply(hash_fn, axis=1, result_type='expand')
         X_cat.columns = new_cols
 
         X = pd.concat([X_cat, X_num], axis=1)


### PR DESCRIPTION
I used the hash-encoder the other day and was surprised by the time it takes for a theorically quite lightweight algorithm. 

I looked into it in a bit more detail, generating a random dataframe with 100,000 rows to measure performance. It turns out that in that case >50% of the time is spent in the `pandas.Series` constructor. [Here's my notebook](https://gist.github.com/bkhant1/b6780714831219a0b3d517849322b039) if you are curious!

## Proposed Changes

  - Returns the already-constructed list in `hash_fn` instead of `pandas.Series`, and use `result_type="expand"` in `apply` the expand the lists into a dataframe.

## Result

Here's the performance table comparision

| Dataframe #columns, #rows / #nb_components, #nb_process | `pandas.Series` | Raw `list` |
|----------|-------------|------|
| 3, 30 / 10, 4 | 5.05s | 5.23s |
| 3, 30 / 10, 1 | 2.1s | 2.08s |
| 3, 30 / 100, 1 | 2.09s | 2.21s |
| 10, 10k / 10, 4 | 7.94s | 7.59s |
| 10, 10k / 10, 1 | 3.5s | 2.31s |
| 50, 1000k / 10, 4 | 1min30s | 51.4s |
| 50, 1000k / 10, 1 | 4min8s | 2min |

For larger dataframes, it slashes the time it takes to `transform` in two. [Here's the notebook](https://gist.github.com/bkhant1/6b56b82fac513180af873bf097c4df67) those results are from.

## Follow-up

I thought I would start with this change as it's a 2-liner!

But there are still some things I would want to look into:
- the multiprocessing seems to slow down things for smaller dataframes
- there might be a way around using `apply` which is know to be slow
- there might be a way to make the communication between processes faster when multiprocessing
