### PR TITLE
Fix/issue 384

### DIFF
--- a/category_encoders/backward_difference.py
+++ b/category_encoders/backward_difference.py
@@ -35,39 +35,33 @@ class BackwardDifferenceEncoder(BaseContrastEncoder):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = BackwardDifferenceEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = BackwardDifferenceEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 21 columns):
-    intercept    506 non-null int64
-    CRIM         506 non-null float64
-    ZN           506 non-null float64
-    INDUS        506 non-null float64
-    CHAS_0       506 non-null float64
-    NOX          506 non-null float64
-    RM           506 non-null float64
-    AGE          506 non-null float64
-    DIS          506 non-null float64
-    RAD_0        506 non-null float64
-    RAD_1        506 non-null float64
-    RAD_2        506 non-null float64
-    RAD_3        506 non-null float64
-    RAD_4        506 non-null float64
-    RAD_5        506 non-null float64
-    RAD_6        506 non-null float64
-    RAD_7        506 non-null float64
-    TAX          506 non-null float64
-    PTRATIO      506 non-null float64
-    B            506 non-null float64
-    LSTAT        506 non-null float64
-    dtypes: float64(20), int64(1)
-    memory usage: 83.1 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 12 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   intercept     1460 non-null   int64  
+     1   Id            1460 non-null   float64
+     2   MSSubClass    1460 non-null   float64
+     3   MSZoning      1460 non-null   object 
+     4   LotFrontage   1201 non-null   float64
+     5   YearBuilt     1460 non-null   float64
+     6   Heating_0     1460 non-null   float64
+     7   Heating_1     1460 non-null   float64
+     8   Heating_2     1460 non-null   float64
+     9   Heating_3     1460 non-null   float64
+     10  Heating_4     1460 non-null   float64
+     11  CentralAir_0  1460 non-null   float64
+    dtypes: float64(10), int64(1), object(1)
+    memory usage: 137.0+ KB
     None
 
     References

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -62,36 +62,31 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = BaseNEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = BaseNEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 18 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS_0     506 non-null int64
-    CHAS_1     506 non-null int64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD_0      506 non-null int64
-    RAD_1      506 non-null int64
-    RAD_2      506 non-null int64
-    RAD_3      506 non-null int64
-    RAD_4      506 non-null int64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(11), int64(7)
-    memory usage: 71.3 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 10 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   Id            1460 non-null   float64
+     1   MSSubClass    1460 non-null   float64
+     2   MSZoning      1460 non-null   object 
+     3   LotFrontage   1201 non-null   float64
+     4   YearBuilt     1460 non-null   float64
+     5   Heating_0     1460 non-null   int64  
+     6   Heating_1     1460 non-null   int64  
+     7   Heating_2     1460 non-null   int64  
+     8   CentralAir_0  1460 non-null   int64  
+     9   CentralAir_1  1460 non-null   int64  
+    dtypes: float64(4), int64(5), object(1)
+    memory usage: 114.2+ KB
     None
 
     """

--- a/category_encoders/binary.py
+++ b/category_encoders/binary.py
@@ -33,36 +33,31 @@ class BinaryEncoder(BaseNEncoder):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = BinaryEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = BinaryEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 18 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS_0     506 non-null int64
-    CHAS_1     506 non-null int64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD_0      506 non-null int64
-    RAD_1      506 non-null int64
-    RAD_2      506 non-null int64
-    RAD_3      506 non-null int64
-    RAD_4      506 non-null int64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(11), int64(7)
-    memory usage: 71.3 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 10 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   Id            1460 non-null   float64
+     1   MSSubClass    1460 non-null   float64
+     2   MSZoning      1460 non-null   object 
+     3   LotFrontage   1201 non-null   float64
+     4   YearBuilt     1460 non-null   float64
+     5   Heating_0     1460 non-null   int64  
+     6   Heating_1     1460 non-null   int64  
+     7   Heating_2     1460 non-null   int64  
+     8   CentralAir_0  1460 non-null   int64  
+     9   CentralAir_1  1460 non-null   int64  
+    dtypes: float64(4), int64(5), object(1)
+    memory usage: 114.2+ KB
     None
 
     """

--- a/category_encoders/cat_boost.py
+++ b/category_encoders/cat_boost.py
@@ -54,31 +54,28 @@ class CatBoostEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = CatBoostEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = CatBoostEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -71,34 +71,30 @@ class CountEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         Example
         -------
         >>> import pandas as pd
-        >>> from sklearn.datasets import load_boston
+        >>> from sklearn.datasets import fetch_openml
         >>> from category_encoders import CountEncoder
 
-        >>> bunch = load_boston()
+        >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+        >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
         >>> y = bunch.target
-        >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-        >>> enc = CountEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+        >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+        >>> enc = CountEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
         >>> numeric_dataset = enc.transform(X)
-
         >>> print(numeric_dataset.info())
         <class 'pandas.core.frame.DataFrame'>
-        RangeIndex: 506 entries, 0 to 505
-        Data columns (total 13 columns):
-        CRIM       506 non-null float64
-        ZN         506 non-null float64
-        INDUS      506 non-null float64
-        CHAS       506 non-null int64
-        NOX        506 non-null float64
-        RM         506 non-null float64
-        AGE        506 non-null float64
-        DIS        506 non-null float64
-        RAD        506 non-null int64
-        TAX        506 non-null float64
-        PTRATIO    506 non-null float64
-        B          506 non-null float64
-        LSTAT      506 non-null float64
-        dtypes: float64(11), int64(2)
-        memory usage: 51.5 KB
+        RangeIndex: 1460 entries, 0 to 1459
+        Data columns (total 7 columns):
+         #   Column       Non-Null Count  Dtype  
+        ---  ------       --------------  -----  
+         0   Id           1460 non-null   float64
+         1   MSSubClass   1460 non-null   float64
+         2   MSZoning     1460 non-null   object 
+         3   LotFrontage  1201 non-null   float64
+         4   YearBuilt    1460 non-null   float64
+         5   Heating      1460 non-null   int64  
+         6   CentralAir   1460 non-null   int64  
+        dtypes: float64(4), int64(2), object(1)
+        memory usage: 80.0+ KB
         None
 
         References

--- a/category_encoders/glmm.py
+++ b/category_encoders/glmm.py
@@ -60,31 +60,28 @@ class GLMMEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
-    >>> y = bunch.target > 22.5
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = GLMMEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
+    >>> y = bunch.target > 200000
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = GLMMEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References

--- a/category_encoders/gray.py
+++ b/category_encoders/gray.py
@@ -40,36 +40,31 @@ class GrayEncoder(BaseNEncoder):
     -------
     >>> from category_encoders import GrayEncoder
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = GrayEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = GrayEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 18 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS_0     506 non-null int64
-    CHAS_1     506 non-null int64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD_0      506 non-null int64
-    RAD_1      506 non-null int64
-    RAD_2      506 non-null int64
-    RAD_3      506 non-null int64
-    RAD_4      506 non-null int64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(11), int64(7)
-    memory usage: 71.3 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 10 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   Id            1460 non-null   float64
+     1   MSSubClass    1460 non-null   float64
+     2   MSZoning      1460 non-null   object 
+     3   LotFrontage   1201 non-null   float64
+     4   YearBuilt     1460 non-null   float64
+     5   Heating_0     1460 non-null   int64  
+     6   Heating_1     1460 non-null   int64  
+     7   Heating_2     1460 non-null   int64  
+     8   CentralAir_0  1460 non-null   int64  
+     9   CentralAir_1  1460 non-null   int64  
+    dtypes: float64(4), int64(5), object(1)
+    memory usage: 114.2+ KB
     None
 
     References

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -61,37 +61,34 @@ class HashingEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
     -------
     >>> from category_encoders.hashing import HashingEncoder
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
     >>> y = bunch.target
-    >>> he = HashingEncoder(cols=['CHAS', 'RAD']).fit(X, y)
-    >>> data = he.transform(X)
-    >>> print(data.info())
+    >>> he = HashingEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
+    >>> numeric_dataset = he.transform(X)
+    >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 19 columns):
-    col_0      506 non-null int64
-    col_1      506 non-null int64
-    col_2      506 non-null int64
-    col_3      506 non-null int64
-    col_4      506 non-null int64
-    col_5      506 non-null int64
-    col_6      506 non-null int64
-    col_7      506 non-null int64
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(11), int64(8)
-    memory usage: 75.2 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 13 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   col_0        1460 non-null   int64  
+     1   col_1        1460 non-null   int64  
+     2   col_2        1460 non-null   int64  
+     3   col_3        1460 non-null   int64  
+     4   col_4        1460 non-null   int64  
+     5   col_5        1460 non-null   int64  
+     6   col_6        1460 non-null   int64  
+     7   col_7        1460 non-null   int64  
+     8   Id           1460 non-null   float64
+     9   MSSubClass   1460 non-null   float64
+     10  MSZoning     1460 non-null   object 
+     11  LotFrontage  1201 non-null   float64
+     12  YearBuilt    1460 non-null   float64
+    dtypes: float64(4), int64(8), object(1)
+    memory usage: 148.4+ KB
     None
 
     References

--- a/category_encoders/helmert.py
+++ b/category_encoders/helmert.py
@@ -36,39 +36,33 @@ class HelmertEncoder(BaseContrastEncoder):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = HelmertEncoder(cols=['CHAS', 'RAD'], handle_unknown='value', handle_missing='value').fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = HelmertEncoder(cols=['CentralAir', 'Heating'], handle_unknown='value', handle_missing='value').fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 21 columns):
-    intercept    506 non-null int64
-    CRIM         506 non-null float64
-    ZN           506 non-null float64
-    INDUS        506 non-null float64
-    CHAS_0       506 non-null float64
-    NOX          506 non-null float64
-    RM           506 non-null float64
-    AGE          506 non-null float64
-    DIS          506 non-null float64
-    RAD_0        506 non-null float64
-    RAD_1        506 non-null float64
-    RAD_2        506 non-null float64
-    RAD_3        506 non-null float64
-    RAD_4        506 non-null float64
-    RAD_5        506 non-null float64
-    RAD_6        506 non-null float64
-    RAD_7        506 non-null float64
-    TAX          506 non-null float64
-    PTRATIO      506 non-null float64
-    B            506 non-null float64
-    LSTAT        506 non-null float64
-    dtypes: float64(20), int64(1)
-    memory usage: 83.1 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 12 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   intercept     1460 non-null   int64  
+     1   Id            1460 non-null   float64
+     2   MSSubClass    1460 non-null   float64
+     3   MSZoning      1460 non-null   object 
+     4   LotFrontage   1201 non-null   float64
+     5   YearBuilt     1460 non-null   float64
+     6   Heating_0     1460 non-null   float64
+     7   Heating_1     1460 non-null   float64
+     8   Heating_2     1460 non-null   float64
+     9   Heating_3     1460 non-null   float64
+     10  Heating_4     1460 non-null   float64
+     11  CentralAir_0  1460 non-null   float64
+    dtypes: float64(10), int64(1), object(1)
+    memory usage: 137.0+ KB
     None
 
     References

--- a/category_encoders/james_stein.py
+++ b/category_encoders/james_stein.py
@@ -89,31 +89,28 @@ class JamesSteinEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = JamesSteinEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = JamesSteinEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References

--- a/category_encoders/leave_one_out.py
+++ b/category_encoders/leave_one_out.py
@@ -40,31 +40,28 @@ class LeaveOneOutEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = LeaveOneOutEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = LeaveOneOutEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References

--- a/category_encoders/m_estimate.py
+++ b/category_encoders/m_estimate.py
@@ -44,31 +44,28 @@ class MEstimateEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
-    >>> y = bunch.target > 22.5
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = MEstimateEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
+    >>> y = bunch.target > 200000
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = MEstimateEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -45,42 +45,36 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = OneHotEncoder(cols=['CHAS', 'RAD'], handle_unknown='indicator').fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = OneHotEncoder(cols=['CentralAir', 'Heating'], handle_unknown='indicator').fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 24 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS_1     506 non-null int64
-    CHAS_2     506 non-null int64
-    CHAS_-1    506 non-null int64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD_1      506 non-null int64
-    RAD_2      506 non-null int64
-    RAD_3      506 non-null int64
-    RAD_4      506 non-null int64
-    RAD_5      506 non-null int64
-    RAD_6      506 non-null int64
-    RAD_7      506 non-null int64
-    RAD_8      506 non-null int64
-    RAD_9      506 non-null int64
-    RAD_-1     506 non-null int64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(11), int64(13)
-    memory usage: 95.0 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 15 columns):
+     #   Column         Non-Null Count  Dtype  
+    ---  ------         --------------  -----  
+     0   Id             1460 non-null   float64
+     1   MSSubClass     1460 non-null   float64
+     2   MSZoning       1460 non-null   object 
+     3   LotFrontage    1201 non-null   float64
+     4   YearBuilt      1460 non-null   float64
+     5   Heating_1      1460 non-null   int64  
+     6   Heating_2      1460 non-null   int64  
+     7   Heating_3      1460 non-null   int64  
+     8   Heating_4      1460 non-null   int64  
+     9   Heating_5      1460 non-null   int64  
+     10  Heating_6      1460 non-null   int64  
+     11  Heating_-1     1460 non-null   int64  
+     12  CentralAir_1   1460 non-null   int64  
+     13  CentralAir_2   1460 non-null   int64  
+     14  CentralAir_-1  1460 non-null   int64  
+    dtypes: float64(4), int64(10), object(1)
+    memory usage: 171.2+ KB
     None
 
     References

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -45,31 +45,28 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = OrdinalEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = OrdinalEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null int64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null int64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(11), int64(2)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   int64  
+     6   CentralAir   1460 non-null   int64  
+    dtypes: float64(4), int64(2), object(1)
+    memory usage: 80.0+ KB
     None
 
     References
@@ -219,9 +216,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         else:
             mapping_out = []
             for col in cols:
-
                 nan_identity = np.nan
-                
                 categories = list(X[col].unique())
                 if util.is_category(X[col].dtype):
                     # Avoid using pandas category dtype meta-data if possible, see #235, #238.

--- a/category_encoders/polynomial.py
+++ b/category_encoders/polynomial.py
@@ -35,39 +35,33 @@ class PolynomialEncoder(BaseContrastEncoder):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = PolynomialEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = PolynomialEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 21 columns):
-    intercept    506 non-null int64
-    CRIM         506 non-null float64
-    ZN           506 non-null float64
-    INDUS        506 non-null float64
-    CHAS_0       506 non-null float64
-    NOX          506 non-null float64
-    RM           506 non-null float64
-    AGE          506 non-null float64
-    DIS          506 non-null float64
-    RAD_0        506 non-null float64
-    RAD_1        506 non-null float64
-    RAD_2        506 non-null float64
-    RAD_3        506 non-null float64
-    RAD_4        506 non-null float64
-    RAD_5        506 non-null float64
-    RAD_6        506 non-null float64
-    RAD_7        506 non-null float64
-    TAX          506 non-null float64
-    PTRATIO      506 non-null float64
-    B            506 non-null float64
-    LSTAT        506 non-null float64
-    dtypes: float64(20), int64(1)
-    memory usage: 83.1 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 12 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   intercept     1460 non-null   int64  
+     1   Id            1460 non-null   float64
+     2   MSSubClass    1460 non-null   float64
+     3   MSZoning      1460 non-null   object 
+     4   LotFrontage   1201 non-null   float64
+     5   YearBuilt     1460 non-null   float64
+     6   Heating_0     1460 non-null   float64
+     7   Heating_1     1460 non-null   float64
+     8   Heating_2     1460 non-null   float64
+     9   Heating_3     1460 non-null   float64
+     10  Heating_4     1460 non-null   float64
+     11  CentralAir_0  1460 non-null   float64
+    dtypes: float64(10), int64(1), object(1)
+    memory usage: 137.0+ KB
     None
 
     References

--- a/category_encoders/quantile_encoder.py
+++ b/category_encoders/quantile_encoder.py
@@ -47,31 +47,28 @@ class QuantileEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = QuantileEncoder(cols=['CHAS', 'RAD'], quantile=0.5, m=1.0).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = QuantileEncoder(cols=["CentralAir", "Heating"], quantile=0.5, m=1.0).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References
@@ -196,39 +193,33 @@ class SummaryEncoder(BaseEstimator, util.TransformerWithTargetMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = SummaryEncoder(cols=["CHAS", "RAD"], quantiles=[0.25, 0.5, 0.75]).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = SummaryEncoder(cols=["CentralAir", "Heating"], quantiles=[0.25, 0.5, 0.75]).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 19 columns):
-    #   Column   Non-Null Count  Dtype  
-    ---  ------   --------------  -----  
-    0   CRIM     506 non-null    float64
-    1   ZN       506 non-null    float64
-    2   INDUS    506 non-null    float64
-    3   CHAS     506 non-null    float64
-    4   NOX      506 non-null    float64
-    5   RM       506 non-null    float64
-    6   AGE      506 non-null    float64
-    7   DIS      506 non-null    float64
-    8   RAD      506 non-null    float64
-    9   TAX      506 non-null    float64
-    10  PTRATIO  506 non-null    float64
-    11  B        506 non-null    float64
-    12  LSTAT    506 non-null    float64
-    13  CHAS_25  506 non-null    float64
-    14  RAD_25   506 non-null    float64
-    15  CHAS_50  506 non-null    float64
-    16  RAD_50   506 non-null    float64
-    17  CHAS_75  506 non-null    float64
-    18  RAD_75   506 non-null    float64
-    dtypes: float64(19)
-    memory usage: 75.2 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 11 columns):
+     #   Column         Non-Null Count  Dtype  
+    ---  ------         --------------  -----  
+     0   Id             1460 non-null   float64
+     1   MSSubClass     1460 non-null   float64
+     2   MSZoning       1460 non-null   object 
+     3   LotFrontage    1201 non-null   float64
+     4   YearBuilt      1460 non-null   float64
+     5   Heating_25     1460 non-null   float64
+     6   Heating_50     1460 non-null   float64
+     7   Heating_75     1460 non-null   float64
+     8   CentralAir_25  1460 non-null   float64
+     9   CentralAir_50  1460 non-null   float64
+     10  CentralAir_75  1460 non-null   float64
+    dtypes: float64(10), object(1)
+    memory usage: 125.6+ KB
+    None
 
     References
     ----------

--- a/category_encoders/sum_coding.py
+++ b/category_encoders/sum_coding.py
@@ -35,39 +35,33 @@ class SumEncoder(BaseContrastEncoder):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
     >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = SumEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = SumEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 21 columns):
-    intercept    506 non-null int64
-    CRIM         506 non-null float64
-    ZN           506 non-null float64
-    INDUS        506 non-null float64
-    CHAS_0       506 non-null float64
-    NOX          506 non-null float64
-    RM           506 non-null float64
-    AGE          506 non-null float64
-    DIS          506 non-null float64
-    RAD_0        506 non-null float64
-    RAD_1        506 non-null float64
-    RAD_2        506 non-null float64
-    RAD_3        506 non-null float64
-    RAD_4        506 non-null float64
-    RAD_5        506 non-null float64
-    RAD_6        506 non-null float64
-    RAD_7        506 non-null float64
-    TAX          506 non-null float64
-    PTRATIO      506 non-null float64
-    B            506 non-null float64
-    LSTAT        506 non-null float64
-    dtypes: float64(20), int64(1)
-    memory usage: 83.1 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 12 columns):
+     #   Column        Non-Null Count  Dtype  
+    ---  ------        --------------  -----  
+     0   intercept     1460 non-null   int64  
+     1   Id            1460 non-null   float64
+     2   MSSubClass    1460 non-null   float64
+     3   MSZoning      1460 non-null   object 
+     4   LotFrontage   1201 non-null   float64
+     5   YearBuilt     1460 non-null   float64
+     6   Heating_0     1460 non-null   float64
+     7   Heating_1     1460 non-null   float64
+     8   Heating_2     1460 non-null   float64
+     9   Heating_3     1460 non-null   float64
+     10  Heating_4     1460 non-null   float64
+     11  CentralAir_0  1460 non-null   float64
+    dtypes: float64(10), int64(1), object(1)
+    memory usage: 137.0+ KB
     None
 
     References

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -58,31 +58,28 @@ class TargetEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
-    >>> y = bunch.target
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = TargetEncoder(cols=['CHAS', 'RAD'], min_samples_leaf=20, smoothing=10).fit(X, y)
+    >>> from sklearn.datasets import fetch_openml
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> y = bunch.target > 200000
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = TargetEncoder(cols=['CentralAir', 'Heating'], min_samples_leaf=20, smoothing=10).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
    
     >>> from category_encoders.datasets import load_compass

--- a/category_encoders/woe.py
+++ b/category_encoders/woe.py
@@ -39,31 +39,28 @@ class WOEEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
     -------
     >>> from category_encoders import *
     >>> import pandas as pd
-    >>> from sklearn.datasets import load_boston
-    >>> bunch = load_boston()
-    >>> y = bunch.target > 22.5
-    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names_out_)
-    >>> enc = WOEEncoder(cols=['CHAS', 'RAD']).fit(X, y)
+    >>> from sklearn.datasets import fetch_openml
+    >>> bunch = fetch_openml(name="house_prices", as_frame=True)
+    >>> display_cols = ["Id", "MSSubClass", "MSZoning", "LotFrontage", "YearBuilt", "Heating", "CentralAir"]
+    >>> y = bunch.target > 200000
+    >>> X = pd.DataFrame(bunch.data, columns=bunch.feature_names)[display_cols]
+    >>> enc = WOEEncoder(cols=['CentralAir', 'Heating']).fit(X, y)
     >>> numeric_dataset = enc.transform(X)
     >>> print(numeric_dataset.info())
     <class 'pandas.core.frame.DataFrame'>
-    RangeIndex: 506 entries, 0 to 505
-    Data columns (total 13 columns):
-    CRIM       506 non-null float64
-    ZN         506 non-null float64
-    INDUS      506 non-null float64
-    CHAS       506 non-null float64
-    NOX        506 non-null float64
-    RM         506 non-null float64
-    AGE        506 non-null float64
-    DIS        506 non-null float64
-    RAD        506 non-null float64
-    TAX        506 non-null float64
-    PTRATIO    506 non-null float64
-    B          506 non-null float64
-    LSTAT      506 non-null float64
-    dtypes: float64(13)
-    memory usage: 51.5 KB
+    RangeIndex: 1460 entries, 0 to 1459
+    Data columns (total 7 columns):
+     #   Column       Non-Null Count  Dtype  
+    ---  ------       --------------  -----  
+     0   Id           1460 non-null   float64
+     1   MSSubClass   1460 non-null   float64
+     2   MSZoning     1460 non-null   object 
+     3   LotFrontage  1201 non-null   float64
+     4   YearBuilt    1460 non-null   float64
+     5   Heating      1460 non-null   float64
+     6   CentralAir   1460 non-null   float64
+    dtypes: float64(6), object(1)
+    memory usage: 80.0+ KB
     None
 
     References

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.0
-scikit-learn>=0.20.0
+scikit-learn>=1.0.0
 scipy>=1.0.0
 statsmodels>=0.9.0
 pandas>=1.0.5

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -46,13 +46,12 @@ def create_dataset(n_rows=1000, extras=False, has_missing=True, random_seed=2001
         random.choice(['A', 'B_b', 'C_c_c']),                                                   # Strings with underscores to test reverse_dummies()
         random.choice(['A', 'B', 'C', np.NaN]) if has_missing else random.choice(['A', 'B', 'C']), # None
         random.choice(['A', 'B', 'C', 'D']) if extras else random.choice(['A', 'B', 'C']),      # With a new string value
-        random.choice([12, 43, -32]),                                                           # Number in the column name
         random.choice(['A', 'B', 'C']),                                                         # What is going to become the categorical column
         random.choice(['A', 'B', 'C', np.nan]),                                                 # Categorical with missing values
         random.choice([1, 2, 3])                                                                # Ordinal integers
     ] for row in range(n_rows)]
 
-    df = pd.DataFrame(ds, columns=['float', 'float_edge', 'unique_int', 'unique_str', 'invariant', 'underscore', 'none', 'extra', 321, 'categorical', 'na_categorical', 'categorical_int'])
+    df = pd.DataFrame(ds, columns=['float', 'float_edge', 'unique_int', 'unique_str', 'invariant', 'underscore', 'none', 'extra', 'categorical', 'na_categorical', 'categorical_int'])
     df['categorical'] = pd.Categorical(df['categorical'], categories=['A', 'B', 'C'])
     df['na_categorical'] = pd.Categorical(df['na_categorical'], categories=['A', 'B', 'C'])
     df['categorical_int'] = pd.Categorical(df['categorical_int'], categories=[1, 2, 3])

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -48,7 +48,7 @@ class TestEncoders(TestCase):
     def test_classification(self):
         for encoder_name in encoders.__all__:
             with self.subTest(encoder_name=encoder_name):
-                cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical', 'na_categorical', 'categorical_int']
+                cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 'categorical', 'na_categorical', 'categorical_int']
 
                 enc = getattr(encoders, encoder_name)(cols=cols)
                 enc.fit(X, np_y)
@@ -249,7 +249,7 @@ class TestEncoders(TestCase):
         # we do not allow None in these data (but "none" column without any missing value is ok)
         X = th.create_dataset(n_rows=100, has_missing=False)
         X_t = th.create_dataset(n_rows=50, has_missing=False)
-        cols = ['underscore', 'none', 321, 'categorical', 'categorical_int']
+        cols = ['underscore', 'none', 'categorical', 'categorical_int']
 
         for encoder_name in ['BaseNEncoder', 'BinaryEncoder', 'OneHotEncoder', 'OrdinalEncoder']:
             with self.subTest(encoder_name=encoder_name):
@@ -403,7 +403,7 @@ class TestEncoders(TestCase):
     def test_cols(self):
         # Test cols argument with different data types, which are array-like or scalars
         cols_list = ['extra', 'invariant']
-        cols_types = [cols_list, pd.Series(cols_list), np.array(cols_list), 'extra', 321, set(cols_list),
+        cols_types = [cols_list, pd.Series(cols_list), np.array(cols_list), 'extra', set(cols_list),
                       ('extra', 'invariant'), pd.Categorical(cols_list, categories=cols_list)]
 
         for encoder_name in encoders.__all__:
@@ -713,7 +713,6 @@ class TestEncoders(TestCase):
         self.assertTrue(result['float'].min() < 1, 'should still be a number and untouched')
         self.assertTrue(result['float_edge'].min() < 1, 'should still be a number and untouched')
         self.assertTrue(result['unique_int'].min() < 1, 'should still be a number and untouched')
-        self.assertTrue(result[321].min() < 1, 'should still be a number')
 
     def test_ignored_columns_are_untouched(self):
         # Make sure None values in ignored columns are preserved.

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -432,14 +432,17 @@ class TestEncoders(TestCase):
     def test_string_index(self):
         # https://github.com/scikit-learn-contrib/categorical-encoding/issues/131
 
-        bunch = sklearn.datasets.load_boston()
-        y = (bunch.target > 20)
+        bunch = sklearn.datasets.fetch_openml(name="house_prices", as_frame=True)
+        y = (bunch.target > 200000).values
         X = pd.DataFrame(bunch.data, columns=bunch.feature_names)
         X.index = X.index.values.astype(str)
 
+        display_cols = ["Id", "MSSubClass", "MSZoning", "YearBuilt", "Heating", "CentralAir"]
+        X = X[display_cols]
+
         for encoder_name in encoders.__all__:
             with self.subTest(encoder_name=encoder_name):
-                enc = getattr(encoders, encoder_name)(cols=['CHAS', 'RAD'])
+                enc = getattr(encoders, encoder_name)(cols=['CentralAir', 'Heating'])
                 result = enc.fit_transform(X, y)
                 self.assertFalse(result.isnull().values.any(), 'There should not be any missing value!')
 

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -47,7 +47,7 @@ class TestOneHotEncoderTestCase(TestCase):
         # test inverse_transform
         X_i = th.create_dataset(n_rows=100, has_missing=False)
         X_i_t = th.create_dataset(n_rows=50, has_missing=False)
-        cols = ['underscore', 'none', 'extra', 321, 'categorical']
+        cols = ['underscore', 'none', 'extra', 'categorical']
 
         enc = encoders.OneHotEncoder(verbose=1, use_cat_names=True, cols=cols)
         enc.fit(X_i)

--- a/tests/test_ordinal.py
+++ b/tests/test_ordinal.py
@@ -242,7 +242,7 @@ class TestOrdinalEncoder(TestCase):
 
     def test_inverse_with_mapping(self):
         df = X.copy(deep=True)
-        categoricals = ['unique_int', 'unique_str', 'invariant', 'underscore', 'none', 'extra', 321]
+        categoricals = ['unique_int', 'unique_str', 'invariant', 'underscore', 'none', 'extra']
         mapping = [{'col': c, 'mapping': pd.Series(data=range(len(df[c].unique())), index=df[c].unique()), 'data_type': X[c].dtype} for c in categoricals]
         enc = encoders.OrdinalEncoder(cols=categoricals, handle_unknown='ignore', mapping=mapping, return_df=True)
         df[categoricals] = enc.fit_transform(df[categoricals])

--- a/tests/test_woe.py
+++ b/tests/test_woe.py
@@ -17,7 +17,7 @@ y_t = pd.DataFrame(np_y_t)
 
 class TestWeightOfEvidenceEncoder(TestCase):
     def test_woe(self):
-        cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 321, 'categorical', 'na_categorical', 'categorical_int']
+        cols = ['unique_str', 'underscore', 'extra', 'none', 'invariant', 'categorical', 'na_categorical', 'categorical_int']
 
         # balanced label with balanced features
         X_balanced = pd.DataFrame(data=['1', '1', '1', '2', '2', '2'], columns=['col1'])


### PR DESCRIPTION
Fixes #384 

## Proposed Changes
Make cateory encoders compatible with sklearn 1.2

  - Get rid of deprecated boston housing dataset
  - fix doctests (and some bugs discovered by it)
  - force sklearn >= 1 as dependency (c.f. #365)
  - delete support for dataframes with mixed column names (strings and ints as column names of a single df)