### PR TITLE
Fix basen_to_integer when column name contains regex metachar

### DIFF
--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -266,7 +266,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         out_cols = X.columns.values.tolist()
 
         for col in cols:
-            col_list = [col0 for col0 in out_cols if re.match(str(col)+'_\\d+', str(col0))]
+            col_list = [col0 for col0 in out_cols if re.match(re.escape(str(col))+'_\\d+', str(col0))]
             insert_at = out_cols.index(col_list[0])
 
             if base == 1:

--- a/tests/test_basen.py
+++ b/tests/test_basen.py
@@ -140,6 +140,16 @@ class TestBaseNEncoder(TestCase):
 
         pd.testing.assert_frame_equal(expected, original)
 
+    def test_inverse_transform_HaveRegexMetacharactersInColumnName_ExpectInversed(self):
+        train = pd.DataFrame({'state (2-letter code)': ['il', 'ny', 'ca']})
+
+        enc = encoders.BaseNEncoder()
+        enc.fit(train)
+        result = enc.transform(train)
+        original = enc.inverse_transform(result)
+
+        pd.testing.assert_frame_equal(train, original)
+
     def test_num_cols(self):
         """
         Test that BaseNEncoder produces the correct number of output columns.


### PR DESCRIPTION
Fixes https://github.com/scikit-learn-contrib/category_encoders/issues/392

## Proposed Changes

Adds `re.escape()` when matching columns from the dataset, when doing `inverse_transform` in `BaseNEncoder`.

Without this `re.escape()`, any regex metacharacter is being interpreted by the regex engine, which leads to invalid results or exception being thrown.