### PR TITLE
OneHotEncoder: Adding handle_missing='ignore' option

### DIFF
--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -40,6 +40,8 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         'value' will encode a missing value as 0 in every dummy column.
         'indicator' will treat missingness as its own category, adding an additional dummy column
         (whether there are missing values in the training set or not).
+        'ignore' will encode missing values as 0 in every dummy column, NOT adding an additional category.
+        
 
     Example
     -------
@@ -108,6 +110,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
             'return_nan': 'return_nan',
             'value': 'value',
             'indicator': 'return_nan',
+            'ignore': 'return_nan'
         }[self.handle_missing]
         self.ordinal_encoder = OrdinalEncoder(
             verbose=self.verbose,
@@ -137,7 +140,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
             append_nan_to_index = False
             for cat_name, class_ in values.items():
-                if pd.isna(cat_name) and self.handle_missing == 'return_nan':
+                if pd.isna(cat_name) and self.handle_missing in ['return_nan', 'ignore']:
                     # we don't want a mapping column if return_nan
                     # but do add the index to the end
                     append_nan_to_index = class_
@@ -175,7 +178,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
             if self.handle_missing == 'return_nan':
                 base_df.loc[-2] = np.nan
-            elif self.handle_missing == 'value':
+            elif self.handle_missing in ['value','ignore']:
                 base_df.loc[-2] = 0
 
             mapping.append({'col': col, 'mapping': base_df})

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -160,6 +160,16 @@ class TestOneHotEncoderTestCase(TestCase):
             pd.DataFrame({'x_A': [1, np.nan, 0], 'x_B': [0, np.nan, 1]}),
         )
 
+    def test_HandleMissingIgnore(self):
+        train = pd.DataFrame({'x': ['A', 'B', np.nan]})
+        encoder = encoders.OneHotEncoder(handle_missing='ignore', use_cat_names=True)
+        result = encoder.fit_transform(train)
+        
+        pd.testing.assert_frame_equal(
+            result,
+            pd.DataFrame({'x_A': [1, 0, 0], 'x_B': [0, 1, 0]}),
+        )
+
     def test_HandleMissingIndicator_NanInTrain_ExpectAsColumn(self):
         train = ['A', 'B', np.nan]
 

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -159,16 +159,31 @@ class TestOneHotEncoderTestCase(TestCase):
             result,
             pd.DataFrame({'x_A': [1, np.nan, 0], 'x_B': [0, np.nan, 1]}),
         )
-
+        
     def test_HandleMissingIgnore(self):
-        train = pd.DataFrame({'x': ['A', 'B', np.nan]})
+        train = pd.DataFrame({'x': ['A', 'B', np.nan],
+                              'y': ['A', None, 'A'],
+                              'z': [np.NaN, 'B', 'B']})
+        train['z'] = train['z'].astype('category')
+        
+        expected_result = pd.DataFrame({'x_A': [1, 0, 0],
+                                        'x_B': [0, 1, 0],
+                                        'y_A': [1, 0, 1],
+                                        'z_B': [0, 1, 1]})    
         encoder = encoders.OneHotEncoder(handle_missing='ignore', use_cat_names=True)
         result = encoder.fit_transform(train)
         
-        pd.testing.assert_frame_equal(
-            result,
-            pd.DataFrame({'x_A': [1, 0, 0], 'x_B': [0, 1, 0]}),
-        )
+        pd.testing.assert_frame_equal(result, expected_result)
+        
+    def test_HandleMissingIgnore_ExpectMappingUsed(self):
+        train = pd.DataFrame({'city': ['Chicago', np.NaN,'Geneva']})
+        expected_result = pd.DataFrame({'city_1': [1, 0, 0],
+                                        'city_3': [0, 0, 1]})
+
+        encoder = encoders.OneHotEncoder(handle_missing='ignore')
+        result = encoder.fit(train).transform(train)
+
+        pd.testing.assert_frame_equal(expected_result, result)
 
     def test_HandleMissingIndicator_NanInTrain_ExpectAsColumn(self):
         train = ['A', 'B', np.nan]


### PR DESCRIPTION
Closes #386 

## Proposed Changes

  - added **ignore** option to the `handle_missing` parameter of the `OneHotEncoder`. This will encode `NaN` values as 0 in every dummy column. However, compared to the **value** option, no additional "_nan" category is created.
  - added a simple test for the new option.