### PR TITLE
replace pkg_resources with importlib.resources

### DIFF
--- a/category_encoders/datasets/_base.py
+++ b/category_encoders/datasets/_base.py
@@ -2,7 +2,11 @@
 Base IO code for datasets
 """
 
-import pkg_resources
+try:
+    from importlib.resources import files, as_file
+except ImportError:
+    from importlib_resources import files, as_file
+
 import pandas as pd
 
 def load_compass():
@@ -21,9 +25,9 @@ def load_compass():
 
     """
     data_filename = "data/compass.csv"
-    stream = pkg_resources.resource_filename(__name__, data_filename)
+    stream = files(__name__) / data_filename
 
-    with open(stream) as f:
+    with as_file(stream) as f:
         df = pd.read_csv(f, encoding='latin-1')
     X = df[['index', 'compass', 'HIER_compass_1']]
     y = df['target']
@@ -56,9 +60,9 @@ def load_postcodes(target_type='binary'):
 
     """
     data_filename = "data/postcode_dataset_100.csv"
-    stream = pkg_resources.resource_filename(__name__, data_filename)
+    stream = files(__name__) / data_filename
 
-    with open(stream) as f:
+    with as_file(stream) as f:
         df = pd.read_csv(f, encoding='latin-1')
     X = df[df.columns[~df.columns.str.startswith('target')]]
     y = df[f'target_{target_type}']

--- a/category_encoders/datasets/_base.py
+++ b/category_encoders/datasets/_base.py
@@ -25,7 +25,7 @@ def load_compass():
 
     """
     data_filename = "data/compass.csv"
-    stream = files(__name__) / data_filename
+    stream = files("category_encoders.datasets") / data_filename
 
     with as_file(stream) as f:
         df = pd.read_csv(f, encoding='latin-1')
@@ -60,7 +60,7 @@ def load_postcodes(target_type='binary'):
 
     """
     data_filename = "data/postcode_dataset_100.csv"
-    stream = files(__name__) / data_filename
+    stream = files("category_encoders.datasets") / data_filename
 
     with as_file(stream) as f:
         df = pd.read_csv(f, encoding='latin-1')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ statsmodels>=0.9.0
 pandas>=1.0.5
 patsy>=0.5.1
 unittest2
+importlib_resources ; python_version<"3.9"

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
       'statsmodels>=0.9.0',
       'pandas>=1.0.5',
       'patsy>=0.5.1',
+      'importlib_resources ; python_version<"3.9"',
     ],
     author_email='will@pedalwrencher.com',
     package_data={'': ['datasets/data/*.csv']},


### PR DESCRIPTION
Fixes increasingly loud warnings about the deprecation of `pkg_resources`, as seen on https://github.com/conda-forge/category_encoders-feedstock/pull/23

## Proposed Changes

  - replace use of `pkg_resources` with `importlib.metadata`
    - or `importlib_metdata` on python < 3.9
    - also removes an undeclared `setuptools` dependency, which is not _technically_ stdlib