### PR TITLE
Fix is_categorical_dtype deprecation

### DIFF
--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -6,6 +6,7 @@ import warnings
 import pandas as pd
 import numpy as np
 import sklearn.base
+from pandas.core.dtypes.dtypes import CategoricalDtype
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.exceptions import NotFittedError
 from typing import Dict, List, Optional, Union
@@ -25,7 +26,7 @@ def convert_cols_to_list(cols):
         return list(cols)
     elif isinstance(cols, tuple):
         return list(cols)
-    elif pd.api.types.is_categorical_dtype(cols):
+    elif isinstance(cols, CategoricalDtype):
         return cols.astype(object).tolist()
 
     return cols
@@ -47,7 +48,7 @@ def get_obj_cols(df):
 
 
 def is_category(dtype):
-    return pd.api.types.is_categorical_dtype(dtype)
+    return isinstance(dtype, CategoricalDtype)
 
 
 def convert_inputs(X, y, columns=None, index=None, deep=False):


### PR DESCRIPTION
Fixes deprecation warning for pandas "is_categorical_dtype":
category_encoders/utils.py:50: FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, CategoricalDtype) instead

Check:
https://github.com/pandas-dev/pandas/pull/33385

Replacing instances with the recommended alternative to use "isinstance"