### PR TITLE
add category and string dtypes to default fit columns

### DIFF
--- a/category_encoders/quantile_encoder.py
+++ b/category_encoders/quantile_encoder.py
@@ -281,7 +281,7 @@ class SummaryEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         self.n_features_in_ = len(self.feature_names_in_)
 
         if self.use_default_cols:
-            self.cols = util.get_obj_cols(X)
+            self.cols = util.get_categorical_cols(X)
         else:
             self.cols = util.convert_cols_to_list(self.cols)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 from unittest import TestCase  # or `from unittest import ...` if on Python 3.4+
-from category_encoders.utils import convert_input_vector, convert_inputs
+from category_encoders.utils import convert_input_vector, convert_inputs, get_categorical_cols
 import pandas as pd
 import numpy as np
 
@@ -114,3 +114,9 @@ class TestUtils(TestCase):
 
         # shape mismatch
         self.assertRaises(ValueError, convert_inputs, barray, [1, 2, 3, 4])
+
+    def test_get_categorical_cols(self):
+        df = pd.DataFrame({"col": ["a", "b"]})
+        self.assertEqual(get_categorical_cols(df.astype("object")), ["col"])
+        self.assertEqual(get_categorical_cols(df.astype("category")), ["col"])
+        self.assertEqual(get_categorical_cols(df.astype("string")), ["col"])


### PR DESCRIPTION
Fixes #421

## Proposed Changes

Adding dtypes `category`, `string` and `string[pyarrow]` to the default dtypes used to fit the encoders.
