### PR TITLE
Pandas lints

### DIFF
--- a/category_encoders/base_contrast_encoder.py
+++ b/category_encoders/base_contrast_encoder.py
@@ -132,7 +132,7 @@ class BaseContrastEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
             # reindex actually applies the mapping
             base_df = mod.reindex(X[col])
-            base_df.set_index(X.index, inplace=True)
+            base_df = base_df.set_index(X.index)
             X = pd.concat([base_df, X], axis=1)
 
             old_column_index = cols.index(col)

--- a/category_encoders/base_contrast_encoder.py
+++ b/category_encoders/base_contrast_encoder.py
@@ -119,7 +119,7 @@ class BaseContrastEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
     @staticmethod
     def transform_contrast_coding(X, mapping):
-        cols = X.columns.values.tolist()
+        cols = X.columns.tolist()
 
         # See issue 370 if it is necessary to add an intercept or not.
         X['intercept'] = pd.Series([1] * X.shape[0], index=X.index)

--- a/category_encoders/base_contrast_encoder.py
+++ b/category_encoders/base_contrast_encoder.py
@@ -86,14 +86,14 @@ class BaseContrastEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         return X
 
     @abstractmethod
-    def get_contrast_matrix(self, values_to_encode: np.array) -> ContrastMatrix:
+    def get_contrast_matrix(self, values_to_encode: np.ndarray) -> ContrastMatrix:
         raise NotImplementedError
 
     def fit_contrast_coding(self, col, values, handle_missing, handle_unknown):
         if handle_missing == 'value':
             values = values[values > 0]
 
-        values_to_encode = values.values
+        values_to_encode = values.to_numpy()
 
         if len(values) < 2:
             return pd.DataFrame(index=values_to_encode)

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -237,7 +237,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
             mod = switch.get('mapping')
 
             base_df = mod.reindex(X[col])
-            base_df.set_index(X.index, inplace=True)
+            base_df = base_df.set_index(X.index)
             X = pd.concat([base_df, X], axis=1)
 
             old_column_index = cols.index(col)
@@ -275,7 +275,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 len0 = len(col_list)
                 value_array = np.array([base ** (len0 - 1 - i) for i in range(len0)])
             X.insert(insert_at, col, np.dot(X[col_list].values, value_array.T))
-            X.drop(col_list, axis=1, inplace=True)
+            X = X.drop(col_list, axis=1)
             out_cols = X.columns.values.tolist()
 
         return X

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -188,20 +188,20 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 
         if not list(self.cols):
-            return X if self.return_df else X.values
+            return X if self.return_df else X.to_numpy()
 
         for switch in self.ordinal_encoder.mapping:
             column_mapping = switch.get('mapping')
-            inverse = pd.Series(data=column_mapping.index, index=column_mapping.values)
+            inverse = pd.Series(data=column_mapping.index, index=column_mapping.array)
             X[switch.get('col')] = X[switch.get('col')].map(inverse).astype(switch.get('data_type'))
 
             if self.handle_unknown == 'return_nan' and self.handle_missing == 'return_nan':
                 for col in self.cols:
-                    if X[switch.get('col')].isnull().any():
+                    if X[switch.get('col')].isna().any():
                         warnings.warn("inverse_transform is not supported because transform impute "
                                       f"the unknown category nan when encode {col}")
 
-        return X if self.return_df else X.values
+        return X if self.return_df else X.to_numpy()
 
     def calc_required_digits(self, values):
         # figure out how many digits we need to represent the classes present
@@ -212,7 +212,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
         return digits
 
-    def basen_encode(self, X_in, cols=None):
+    def basen_encode(self, X_in: pd.DataFrame, cols=None):
         """
         Basen encoding encodes the integers as basen code with one column per digit.
 
@@ -230,7 +230,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
         X = X_in.copy(deep=True)
 
-        cols = X.columns.values.tolist()
+        cols = X.columns.tolist()
 
         for switch in self.mapping:
             col = switch.get('col')
@@ -245,7 +245,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
         return X.reindex(columns=cols)
 
-    def basen_to_integer(self, X, cols, base):
+    def basen_to_integer(self, X: pd.DataFrame, cols, base):
         """
         Convert basen code as integers.
 
@@ -263,7 +263,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         numerical: DataFrame
 
         """
-        out_cols = X.columns.values.tolist()
+        out_cols = X.columns.tolist()
 
         for col in cols:
             col_list = [col0 for col0 in out_cols if re.match(re.escape(str(col))+'_\\d+', str(col0))]
@@ -276,7 +276,7 @@ class BaseNEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 value_array = np.array([base ** (len0 - 1 - i) for i in range(len0)])
             X.insert(insert_at, col, np.dot(X[col_list].values, value_array.T))
             X = X.drop(col_list, axis=1)
-            out_cols = X.columns.values.tolist()
+            out_cols = X.columns.tolist()
 
         return X
 

--- a/category_encoders/cat_boost.py
+++ b/category_encoders/cat_boost.py
@@ -121,7 +121,7 @@ class CatBoostEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
             unique_train = colmap.index
             unseen_values = pd.Series([x for x in X[col].unique() if x not in unique_train], dtype=unique_train.dtype)
 
-            is_nan = X[col].isnull()
+            is_nan = X[col].isna()
             is_unknown_value = X[col].isin(unseen_values.dropna().astype(object))
 
             if self.handle_unknown == 'error' and is_unknown_value.any():
@@ -153,7 +153,7 @@ class CatBoostEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
             if self.handle_missing == 'value':
                 # only set value if there are actually missing values.
                 # In case of pd.Categorical columns setting values that are not seen in pd.Categorical gives an error.
-                nan_cond = is_nan & unseen_values.isnull().any()
+                nan_cond = is_nan & unseen_values.isna().any()
                 if nan_cond.any():
                     X.loc[nan_cond, col] = self._mean
             elif self.handle_missing == 'return_nan':

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -158,7 +158,7 @@ class CountEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
             elif (
                     self._handle_unknown[col] == 'error'
-                    and X[col].isnull().any()
+                    and X[col].isna().any()
             ):
                 raise ValueError(f'Missing data found in column {col} at transform time.')
         return X
@@ -168,7 +168,7 @@ class CountEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         X = X_in.copy(deep=True)
 
         if self.cols is None:
-            self.cols = X.columns.values
+            self.cols = X.columns
 
         self.mapping = {}
 
@@ -202,12 +202,12 @@ class CountEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
             elif self._combine_min_nan_groups[col] == 'force':
                 min_groups_idx = (
                     (mapper < self._min_group_size[col])
-                    | (mapper.index.isnull())
+                    | (mapper.index.isna())
                 )
             else:
                 min_groups_idx = (
                     (mapper < self._min_group_size[col])
-                    & (~mapper.index.isnull())
+                    & (~mapper.index.isna())
                 )
 
             min_groups_sum = mapper.loc[min_groups_idx].sum()
@@ -215,7 +215,7 @@ class CountEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
             if (
                 min_groups_sum > 0
                 and min_groups_idx.sum() > 1
-                and not min_groups_idx.loc[~min_groups_idx.index.isnull()].all()
+                and not min_groups_idx.loc[~min_groups_idx.index.isna()].all()
             ):
                 if isinstance(self._min_group_name[col], str):
                     min_group_mapper_name = self._min_group_name[col]

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -154,7 +154,7 @@ class CountEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                   and X[col].isna().any()
                   and self._handle_missing[col] != 'return_nan'
             ):
-                X[col].replace(np.nan, 0, inplace=True)
+                X[col] = X[col].replace(np.nan, 0)
 
             elif (
                     self._handle_unknown[col] == 'error'

--- a/category_encoders/gray.py
+++ b/category_encoders/gray.py
@@ -91,7 +91,7 @@ class GrayEncoder(BaseNEncoder):
             col = col_to_encode["col"]
             bin_mapping = col_to_encode["mapping"]
             n_cols_out = bin_mapping.shape[1]
-            null_cond = (bin_mapping.index < 0) | (bin_mapping.isnull().all(1))
+            null_cond = (bin_mapping.index < 0) | (bin_mapping.isna().all(1))
             map_null = bin_mapping[null_cond]
             map_non_null = bin_mapping[~null_cond].copy()
             ordinal_mapping = [m for m in self.ordinal_encoder.mapping if m.get("col") == col]

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -246,7 +246,7 @@ class HashingEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         if self.return_df or override_return_df:
             return X
         else:
-            return X.values
+            return X.to_numpy()
 
     @staticmethod
     def hashing_trick(X_in, hashing_method='md5', N=2, cols=None, make_copy=False):
@@ -294,11 +294,11 @@ class HashingEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
             X = X_in
 
         if cols is None:
-            cols = X.columns.values
+            cols = X.columns
 
         def hash_fn(x):
             tmp = [0 for _ in range(N)]
-            for val in x.values:
+            for val in x.array:
                 if val is not None:
                     hasher = hashlib.new(hashing_method)
                     if sys.version_info[0] == 2:
@@ -311,7 +311,7 @@ class HashingEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         new_cols = [f'col_{d}' for d in range(N)]
 
         X_cat = X.loc[:, cols]
-        X_num = X.loc[:, [x for x in X.columns.values if x not in cols]]
+        X_num = X.loc[:, [x for x in X.columns if x not in cols]]
 
         X_cat = X_cat.apply(hash_fn, axis=1, result_type='expand')
         X_cat.columns = new_cols

--- a/category_encoders/james_stein.py
+++ b/category_encoders/james_stein.py
@@ -169,7 +169,7 @@ class JamesSteinEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
             unique = y.unique()
             if len(unique) != 2:
                 raise ValueError("The target column y must be binary. But the target contains " + str(len(unique)) + " unique value(s).")
-            if y.isnull().any():
+            if y.isna().any():
                 raise ValueError("The target column y must not contain missing values.")
             if np.max(unique) < 1:
                 raise ValueError("The target column y must be binary with values {0, 1}. Value 1 was not found in the target.")
@@ -357,7 +357,7 @@ class JamesSteinEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
             crosstable['E-A+'] = stats['count'] - stats['sum']
             crosstable['E+A-'] = global_sum - stats['sum']
             crosstable['E+A+'] = stats['sum']
-            index = crosstable.index.values
+            index = crosstable.index
             crosstable = np.array(crosstable, dtype=np.float32)  # The argument unites the types into float
 
             # Count of contingency tables.

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -304,7 +304,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 val = positive_indexes[i]
                 X.loc[X[existing_col] == 1, col] = val
                 mapped_columns.append(existing_col)
-            X.drop(mod.columns, axis=1, inplace=True)
+            X = X.drop(mod.columns, axis=1)
             out_cols = X.columns.values.tolist()
 
         return X

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -227,7 +227,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 
         if not list(self.cols):
-            return X if self.return_df else X.values
+            return X if self.return_df else X.to_numpy()
 
         for switch in self.ordinal_encoder.mapping:
             column_mapping = switch.get('mapping')
@@ -236,11 +236,11 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
             if self.handle_unknown == 'return_nan' and self.handle_missing == 'return_nan':
                 for col in self.cols:
-                    if X[switch.get('col')].isnull().any():
+                    if X[switch.get('col')].isna().any():
                         warnings.warn("inverse_transform is not supported because transform impute "
                                       f"the unknown category nan when encode {col}")
 
-        return X if self.return_df else X.values
+        return X if self.return_df else X.to_numpy()
 
     def get_dummies(self, X_in):
         """
@@ -258,7 +258,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
         X = X_in.copy(deep=True)
 
-        cols = X.columns.values.tolist()
+        cols = X.columns.tolist()
 
         for switch in self.mapping:
             col = switch.get('col')
@@ -290,7 +290,7 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         numerical: DataFrame
 
         """
-        out_cols = X.columns.values.tolist()
+        out_cols = X.columns.tolist()
         mapped_columns = []
         for switch in mapping:
             col = switch.get('col')
@@ -305,6 +305,6 @@ class OneHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 X.loc[X[existing_col] == 1, col] = val
                 mapped_columns.append(existing_col)
             X = X.drop(mod.columns, axis=1)
-            out_cols = X.columns.values.tolist()
+            out_cols = X.columns.tolist()
 
         return X

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -151,7 +151,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 
         if not list(self.cols):
-            return X if self.return_df else X.values
+            return X if self.return_df else X.to_numpy()
 
         if self.handle_unknown == 'value':
             for col in self.cols:
@@ -161,7 +161,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
         if self.handle_unknown == 'return_nan' and self.handle_missing == 'return_nan':
             for col in self.cols:
-                if X[col].isnull().any():
+                if X[col].isna().any():
                     warnings.warn("inverse_transform is not supported because transform impute "
                                   f"the unknown category nan when encode {col}")
 
@@ -170,7 +170,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
             inverse = pd.Series(data=column_mapping.index, index=column_mapping.values)
             X[switch.get('col')] = X[switch.get('col')].map(inverse).astype(switch.get('data_type'))
 
-        return X if self.return_df else X.values
+        return X if self.return_df else X.to_numpy()
 
     @staticmethod
     def ordinal_encoding(X_in, mapping=None, cols=None, handle_unknown='value', handle_missing='value'):
@@ -185,7 +185,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         X = X_in.copy(deep=True)
 
         if cols is None:
-            cols = X.columns.values
+            cols = X.columns
 
         if mapping is not None:
             mapping_out = mapping
@@ -197,7 +197,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 X[column] = pd.Series([el if el is not None else np.NaN for el in X[column]], index=X[column].index)
                 X[column] = X[column].map(col_mapping)
                 if util.is_category(X[column].dtype):
-                    nan_identity = col_mapping.loc[col_mapping.index.isna()].values[0]
+                    nan_identity = col_mapping.loc[col_mapping.index.isna()].array[0]
                     X[column] = X[column].cat.add_categories(nan_identity)
                     X[column] = X[column].fillna(nan_identity)
                 try:
@@ -208,7 +208,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                 if handle_unknown == 'value':
                     X[column] = X[column].fillna(-1)
                 elif handle_unknown == 'error':
-                    missing = X[column].isnull()
+                    missing = X[column].isna()
                     if any(missing):
                         raise ValueError(f'Unexpected categories found in column {column}')
 
@@ -237,7 +237,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
                 data = pd.Series(index=index, data=range(1, len(index) + 1))
 
-                if handle_missing == 'value' and ~data.index.isnull().any():
+                if handle_missing == 'value' and ~data.index.isna().any():
                     data.loc[nan_identity] = -2
                 elif handle_missing == 'return_nan':
                     data.loc[nan_identity] = -2

--- a/category_encoders/ordinal.py
+++ b/category_encoders/ordinal.py
@@ -206,7 +206,7 @@ class OrdinalEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
                     X[column] = X[column].astype(float)
 
                 if handle_unknown == 'value':
-                    X[column].fillna(-1, inplace=True)
+                    X[column] = X[column].fillna(-1)
                 elif handle_unknown == 'error':
                     missing = X[column].isnull()
                     if any(missing):

--- a/category_encoders/quantile_encoder.py
+++ b/category_encoders/quantile_encoder.py
@@ -337,7 +337,7 @@ class SummaryEncoder(BaseEstimator, util.TransformerWithTargetMixin):
         if self.return_df or override_return_df:
             return transformed_df
         else:
-            return transformed_df.values
+            return transformed_df.to_numpy()
 
     def get_feature_names(self) -> List[str]:
         warnings.warn("`get_feature_names` is deprecated in all of sklearn. Use `get_feature_names_out` instead.",

--- a/category_encoders/rankhot.py
+++ b/category_encoders/rankhot.py
@@ -119,7 +119,7 @@ class RankHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
     def _transform(self, X_in, override_return_df=False):
         X = X_in.copy(deep=True)
         X = self.ordinal_encoder.transform(X)
-        input_cols = X.columns.values.tolist()
+        input_cols = X.columns.tolist()
 
         if self.handle_unknown == "error":
             if X[self.cols].isin([-1]).any().any():
@@ -178,7 +178,7 @@ class RankHotEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
 
     def inverse_transform(self, X_in):
         X = X_in.copy(deep=True)
-        cols = X.columns.values.tolist()
+        cols = X.columns.tolist()
         if self._dim is None:
             raise ValueError("Must train encoder before it can be used to inverse_transform data")
 

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -134,7 +134,7 @@ class TargetEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
             self.hierarchy = hierarchy
             self.hierarchy_depth = {}
             for col in self.cols:
-                HIER_cols = self.hierarchy.columns[self.hierarchy.columns.str.startswith(f'HIER_{col}')].array
+                HIER_cols = self.hierarchy.columns[self.hierarchy.columns.str.startswith(f'HIER_{col}')].tolist()
                 HIER_levels = [int(i.replace(f'HIER_{col}_', '')) for i in HIER_cols]
                 if np.array_equal(sorted(HIER_levels), np.arange(1, max(HIER_levels)+1)):
                     self.hierarchy_depth[col] = max(HIER_levels)

--- a/category_encoders/target_encoder.py
+++ b/category_encoders/target_encoder.py
@@ -134,7 +134,7 @@ class TargetEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
             self.hierarchy = hierarchy
             self.hierarchy_depth = {}
             for col in self.cols:
-                HIER_cols = self.hierarchy.columns[self.hierarchy.columns.str.startswith(f'HIER_{col}')].values
+                HIER_cols = self.hierarchy.columns[self.hierarchy.columns.str.startswith(f'HIER_{col}')].array
                 HIER_levels = [int(i.replace(f'HIER_{col}_', '')) for i in HIER_cols]
                 if np.array_equal(sorted(HIER_levels), np.arange(1, max(HIER_levels)+1)):
                     self.hierarchy_depth[col] = max(HIER_levels)

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -306,7 +306,7 @@ class BaseEncoder(BaseEstimator):
             raise ValueError('X does not contain the columns listed in cols')
 
         if self.handle_missing == 'error':
-            if X[self.cols].isnull().any().any():
+            if X[self.cols].isna().any().any():
                 raise ValueError('Columns to be encoded can not contain null')
 
         self._fit(X, y, **kwargs)
@@ -329,7 +329,7 @@ class BaseEncoder(BaseEstimator):
 
     def _check_transform_inputs(self, X):
         if self.handle_missing == 'error':
-            if X[self.cols].isnull().any().any():
+            if X[self.cols].isna().any().any():
                 raise ValueError('Columns to be encoded can not contain null')
 
         if self._dim is None:
@@ -346,7 +346,7 @@ class BaseEncoder(BaseEstimator):
         if self.return_df or override_return_df:
             return X
         else:
-            return X.values
+            return X.to_numpy()
 
     def _determine_fit_columns(self, X: pd.DataFrame) -> None:
         """ Determine columns used by encoder.

--- a/category_encoders/woe.py
+++ b/category_encoders/woe.py
@@ -90,7 +90,7 @@ class WOEEncoder(util.BaseEncoder, util.SupervisedTransformerMixin):
         unique = y.unique()
         if len(unique) != 2:
             raise ValueError("The target column y must be binary. But the target contains " + str(len(unique)) + " unique value(s).")
-        if y.isnull().any():
+        if y.isna().any():
             raise ValueError("The target column y must not contain missing values.")
         if np.max(unique) < 1:
             raise ValueError("The target column y must be binary with values {0, 1}. Value 1 was not found in the target.")

--- a/examples/benchmarking_large/benchmarking_large.py
+++ b/examples/benchmarking_large/benchmarking_large.py
@@ -108,7 +108,7 @@ for dataset_name in datasets:
     y = y.iloc[perm].reset_index(drop=True)
 
     # X, y, fold_count, nominal_columns = csv_loader.load(dataset_name)
-    non_numeric = list(X.select_dtypes(exclude=[np.number]).columns.values)
+    non_numeric = list(X.select_dtypes(exclude=[np.number]).columns)
     for encoder in encoders:
         print("Encoding:", dataset_name, y.name, encoder.__class__.__name__)
         folds, fit_encoder_time, score_encoder_time = train_encoder(X, y, fold_count, encoder)

--- a/examples/benchmarking_large/catboost_comparison.py
+++ b/examples/benchmarking_large/catboost_comparison.py
@@ -87,7 +87,7 @@ for dataset_name in datasets:
 
     # Get indexes (not names) of categorical features
     categorical_indexes = []
-    for col in X.select_dtypes(exclude=[np.number]).columns.values:
+    for col in X.select_dtypes(exclude=[np.number]).columns:
         for i, col2 in enumerate(X.columns):
             if col == col2:
                 categorical_indexes.append(i)

--- a/examples/benchmarking_large/catboost_comparison.py
+++ b/examples/benchmarking_large/catboost_comparison.py
@@ -93,7 +93,7 @@ for dataset_name in datasets:
                 categorical_indexes.append(i)
 
     # Simple missing value treatment
-    X.fillna(-999, inplace=True)
+    X = X.fillna(-999)
 
     # Perform cross-validation
     pool = Pool(X, y, categorical_indexes)

--- a/examples/grid_search_example.py
+++ b/examples/grid_search_example.py
@@ -21,7 +21,7 @@ print(__doc__)
 
 # first get data from the mushroom dataset
 X, y, _ = get_mushroom_data()
-X = X.values  # use numpy array not dataframe here
+X = X.to_numpy()  # use numpy array not dataframe here
 n_samples = X.shape[0]
 
 # split the dataset in two equal parts

--- a/examples/source_data/loaders.py
+++ b/examples/source_data/loaders.py
@@ -12,9 +12,9 @@ def get_cars_data():
     """
 
     df = pd.read_csv('source_data/cars/car.data.txt')
-    X = df.reindex(columns=[x for x in df.columns.values if x != 'class'])
+    X = df.reindex(columns=[x for x in df.columns if x != 'class'])
     y = df.reindex(columns=['class'])
-    y = preprocessing.LabelEncoder().fit_transform(y.values.reshape(-1, ))
+    y = preprocessing.LabelEncoder().fit_transform(y.to_numpy().ravel())
 
     mapping = [
         {'col': 'buying', 'mapping': [('vhigh', 0), ('high', 1), ('med', 2), ('low', 3)]},
@@ -36,9 +36,9 @@ def get_mushroom_data():
     """
 
     df = pd.read_csv('source_data/mushrooms/agaricus-lepiota.csv')
-    X = df.reindex(columns=[x for x in df.columns.values if x != 'class'])
+    X = df.reindex(columns=[x for x in df.columns if x != 'class'])
     y = df.reindex(columns=['class'])
-    y = preprocessing.LabelEncoder().fit_transform(y.values.reshape(-1, ))
+    y = preprocessing.LabelEncoder().fit_transform(y.to_numpy().ravel())
 
     # this data is truly categorical, with no known concept of ordering
     mapping = None
@@ -54,14 +54,14 @@ def get_splice_data():
     """
 
     df = pd.read_csv('source_data/splice/splice.csv')
-    X = df.reindex(columns=[x for x in df.columns.values if x != 'class'])
+    X = df.reindex(columns=[x for x in df.columns if x != 'class'])
     X['dna'] = X['dna'].map(lambda x: list(str(x).strip()))
     for idx in range(60):
         X['dna_%d' % (idx, )] = X['dna'].map(lambda x: x[idx])
     del X['dna']
 
     y = df.reindex(columns=['class'])
-    y = preprocessing.LabelEncoder().fit_transform(y.values.reshape(-1, ))
+    y = preprocessing.LabelEncoder().fit_transform(y.to_numpy().ravel())
 
     # this data is truly categorical, with no known concept of ordering
     mapping = None

--- a/tests/test_backward_difference.py
+++ b/tests/test_backward_difference.py
@@ -17,7 +17,7 @@ class TestBackwardsEncoder(TestCase):
         expected = [[1, -2 / 3.0, -1 / 3.0],
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_backwards_difference_encoder_preserve_dimension_2(self):
         train = ['A', 'B', 'C']
@@ -30,7 +30,7 @@ class TestBackwardsEncoder(TestCase):
         expected = [[1, 1 / 3.0, -1 / 3.0],
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_backwards_difference_encoder_preserve_dimension_3(self):
         train = ['A', 'B', 'C']
@@ -44,7 +44,7 @@ class TestBackwardsEncoder(TestCase):
                     [1, 1 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, 2 / 3.0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_backwards_difference_encoder_preserve_dimension_4(self):
         train = ['A', 'B', 'C']
@@ -58,7 +58,7 @@ class TestBackwardsEncoder(TestCase):
                     [1, 1 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, 2 / 3.0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_backwards_difference_encoder_2cols(self):
         train = [['A', 'A'], ['B', 'B'], ['C', 'C']]
@@ -70,7 +70,7 @@ class TestBackwardsEncoder(TestCase):
         expected = [[1, -2 / 3.0, -1 / 3.0, -2 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, -1 / 3.0, 1 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, 2 / 3.0, 1 / 3.0, 2 / 3.0]]
-        self.assertEqual(obtained.values.tolist(), expected)
+        self.assertEqual(obtained.to_numpy().tolist(), expected)
 
     def test_backwards_difference_encoder_2StringCols_ExpectCorrectOrder(self):
         train = pd.DataFrame({'col1': [1, 2, 3, 4],
@@ -83,7 +83,7 @@ class TestBackwardsEncoder(TestCase):
         encoder = encoders.BackwardDifferenceEncoder(handle_unknown='value', handle_missing='value')
 
         encoder.fit(train)
-        columns = encoder.transform(train).columns.values
+        columns = encoder.transform(train).columns
 
         self.assertTrue(np.array_equal(expected_columns, columns))
 
@@ -96,7 +96,7 @@ class TestBackwardsEncoder(TestCase):
         expected = [[1, -2 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, 2 / 3.0]]
-        self.assertTrue(np.array_equal(result.values.tolist(), expected))
+        self.assertTrue(np.array_equal(result.to_numpy().tolist(), expected))
 
     def test_HandleMissingIndicator_HaveNoNan_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -106,7 +106,7 @@ class TestBackwardsEncoder(TestCase):
 
         expected = [[1, -2 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, -1 / 3.0]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleMissingIndicator_NanNoNanInTrain_ExpectAsNanColumn(self):
         train = ['A', 'B']
@@ -119,7 +119,7 @@ class TestBackwardsEncoder(TestCase):
         expected = [[1, -2 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, 2 / 3.0]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveNoUnknownInTrain_ExpectIndicatorInTest(self):
         train = ['A', 'B']
@@ -132,7 +132,7 @@ class TestBackwardsEncoder(TestCase):
         expected = [[1, -2 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, 2 / 3.0]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveOnlyKnown_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -142,4 +142,4 @@ class TestBackwardsEncoder(TestCase):
 
         expected = [[1, -2 / 3.0, -1 / 3.0],
                     [1, 1 / 3.0, -1 / 3.0]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -37,7 +37,7 @@ class TestCountEncoder(TestCase):
 
         self.assertTrue(pd.Series([5, 3, 6]).isin(out['none'].unique()).all())
         self.assertTrue(out['none'].unique().shape == (3,))
-        self.assertTrue(out['none'].isnull().sum() == 0)
+        self.assertTrue(out['none'].isna().sum() == 0)
         self.assertTrue(pd.Series([6, 3]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (4,))
         self.assertTrue(enc.mapping is not None)
@@ -54,11 +54,11 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._handle_missing)
         self.assertTrue(pd.Series([6, 5, 3]).isin(out['none']).all())
         self.assertTrue(out['none'].unique().shape == (4,))
-        self.assertTrue(out['none'].isnull().sum() == 3)
+        self.assertTrue(out['none'].isna().sum() == 3)
         self.assertTrue(pd.Series([6, 7, 3]).isin(out['na_categorical']).all())
         self.assertFalse(pd.Series([4]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (4,))
-        self.assertTrue(out['na_categorical'].isnull().sum() == 3)
+        self.assertTrue(out['na_categorical'].isna().sum() == 3)
 
     def test_count_handle_missing_dict(self):
         """Test the handle_missing dict on 'none' and 'na_categorical'. 
@@ -73,11 +73,11 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._handle_missing)
         self.assertTrue(pd.Series([5, 3, 6]).isin(out['none']).all())
         self.assertTrue(out['none'].unique().shape == (3,))
-        self.assertTrue(out['none'].isnull().sum() == 0)
+        self.assertTrue(out['none'].isna().sum() == 0)
         self.assertTrue(pd.Series([6, 7, 3]).isin(out['na_categorical']).all())
         self.assertFalse(pd.Series([4]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (4,))
-        self.assertTrue(out['na_categorical'].isnull().sum() == 3)
+        self.assertTrue(out['na_categorical'].isna().sum() == 3)
 
     def test_count_handle_unknown_string(self):
         """Test the handle_unknown string  on 'none' and 'na_categorical'.
@@ -94,10 +94,10 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._handle_unknown)
         self.assertTrue(pd.Series([6, 5, 3]).isin(out['none']).all())
         self.assertTrue(out['none'].unique().shape == (4,))
-        self.assertTrue(out['none'].isnull().sum() == 3)
+        self.assertTrue(out['none'].isna().sum() == 3)
         self.assertTrue(pd.Series([3, 6, 7]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (4,))
-        self.assertTrue(out['na_categorical'].isnull().sum() == 3)
+        self.assertTrue(out['na_categorical'].isna().sum() == 3)
 
     def test_count_handle_unknown_dict(self):
         """Test the 'handle_unkown' dict with all non-default options."""
@@ -115,10 +115,10 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._handle_unknown)
         self.assertTrue(pd.Series([6, 5, 3, -1]).isin(out['none']).all())
         self.assertTrue(out['none'].unique().shape == (4,))
-        self.assertTrue(out['none'].isnull().sum() == 0)
+        self.assertTrue(out['none'].isna().sum() == 0)
         self.assertTrue(pd.Series([3, 6, 7]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (4,))
-        self.assertTrue(out['na_categorical'].isnull().sum() == 3)
+        self.assertTrue(out['na_categorical'].isna().sum() == 3)
 
     def test_count_min_group_size_int(self):
         """Test the min_group_size int  on 'none' and 'na_categorical'."""
@@ -128,7 +128,7 @@ class TestCountEncoder(TestCase):
         out = enc.transform(X_t)
         self.assertTrue(pd.Series([6, 5, 3]).isin(out['none']).all())
         self.assertTrue(out['none'].unique().shape == (3,))
-        self.assertTrue(out['none'].isnull().sum() == 0)
+        self.assertTrue(out['none'].isna().sum() == 0)
         self.assertIn(np.nan, enc.mapping['none'])
         self.assertTrue(pd.Series([13, 7]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (2,))
@@ -146,7 +146,7 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._min_group_size)
         self.assertTrue(pd.Series([6, 8]).isin(out['none']).all())
         self.assertEqual(out['none'].unique().shape[0], 2)
-        self.assertTrue(out['none'].isnull().sum() == 0)
+        self.assertTrue(out['none'].isna().sum() == 0)
         self.assertIn(np.nan, enc.mapping['none'])
         self.assertTrue(pd.Series([13, 7]).isin(out['na_categorical']).all())
         self.assertTrue(out['na_categorical'].unique().shape == (2,))
@@ -165,7 +165,7 @@ class TestCountEncoder(TestCase):
 
         self.assertTrue(pd.Series([6, 5, 3]).isin(out['none']).all())
         self.assertEqual(out['none'].unique().shape[0], 3)
-        self.assertEqual(out['none'].isnull().sum(), 0)
+        self.assertEqual(out['none'].isna().sum(), 0)
         self.assertTrue(pd.Series([9, 7, 4]).isin(out['na_categorical']).all())
         self.assertEqual(out['na_categorical'].unique().shape[0], 3)
         self.assertTrue(enc.mapping is not None)
@@ -190,7 +190,7 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._combine_min_nan_groups)
         self.assertTrue(pd.Series([14, 6]).isin(out['none']).all())
         self.assertEqual(out['none'].unique().shape[0], 2)
-        self.assertEqual(out['none'].isnull().sum(), 0)
+        self.assertEqual(out['none'].isna().sum(), 0)
         self.assertTrue(pd.Series([9, 7, 4]).isin(out['na_categorical']).all())
         self.assertEqual(out['na_categorical'].unique().shape[0], 3)
         self.assertTrue(enc.mapping is not None)
@@ -242,7 +242,7 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._normalize)
         self.assertTrue(out['none'].round(5).isin([0.3, 0.4]).all())
         self.assertEqual(out['none'].unique().shape[0], 2)
-        self.assertEqual(out['none'].isnull().sum(), 0)
+        self.assertEqual(out['none'].isna().sum(), 0)
         self.assertTrue(pd.Series([0.3, 0.35]).isin(out['na_categorical']).all())
         self.assertEqual(out['na_categorical'].unique().shape[0], 2)
         self.assertTrue(enc.mapping is not None)
@@ -262,7 +262,7 @@ class TestCountEncoder(TestCase):
         self.assertIn('none', enc._normalize)
         self.assertTrue(out['none'].round(5).isin([0.3 , 0.15, 0.25]).all())
         self.assertEqual(out['none'].unique().shape[0], 3)
-        self.assertEqual(out['none'].isnull().sum(), 0)
+        self.assertEqual(out['none'].isna().sum(), 0)
         self.assertTrue(pd.Series([13, 7]).isin(out['na_categorical']).all())
         self.assertEqual(out['na_categorical'].unique().shape[0], 2)
         self.assertTrue(enc.mapping is not None)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -194,9 +194,9 @@ class TestEncoders(TestCase):
                 result = enc.transform(test).iloc[1, :]
 
                 if len(result) == 1:
-                    self.assertTrue(result.isnull().all())
+                    self.assertTrue(result.isna().all())
                 else:
-                    self.assertTrue(result[1:].isnull().all())
+                    self.assertTrue(result[1:].isna().all())
 
     def test_handle_missing_return_nan_train(self):
         X = pd.DataFrame({'city': ['chicago', 'los angeles', np.NaN]})
@@ -208,9 +208,9 @@ class TestEncoders(TestCase):
                 result = enc.fit_transform(X, y).iloc[2, :]
 
                 if len(result) == 1:
-                    self.assertTrue(result.isnull().all())
+                    self.assertTrue(result.isna().all())
                 else:
-                    self.assertTrue(result[1:].isnull().all())
+                    self.assertTrue(result[1:].isna().all())
 
     def test_handle_missing_return_nan_test(self):
         X = pd.DataFrame({'city': ['chicago', 'los angeles', 'chicago']})
@@ -223,9 +223,9 @@ class TestEncoders(TestCase):
                 result = enc.fit(X, y).transform(X_t).iloc[2, :]
 
                 if len(result) == 1:
-                    self.assertTrue(result.isnull().all())
+                    self.assertTrue(result.isna().all())
                 else:
-                    self.assertTrue(result[1:].isnull().all())
+                    self.assertTrue(result[1:].isna().all())
 
     def test_handle_unknown_value(self):
         train = pd.DataFrame({'city': ['chicago', 'los angeles']})
@@ -237,7 +237,7 @@ class TestEncoders(TestCase):
                 enc = getattr(encoders, encoder_name)(handle_unknown='value')
                 enc.fit(train, y)
                 result = enc.transform(test)
-                self.assertFalse(result.iloc[1, :].isnull().all())
+                self.assertFalse(result.iloc[1, :].isna().all())
 
     def test_sklearn_compliance(self):
         for encoder_name in encoders.__all__:
@@ -448,7 +448,7 @@ class TestEncoders(TestCase):
             with self.subTest(encoder_name=encoder_name):
                 enc = getattr(encoders, encoder_name)()
                 result = enc.fit_transform(train, target)
-                self.assertFalse(result.isnull().values.any(), 'There should not be any missing value!')
+                self.assertFalse(result.isna().values.any(), 'There should not be any missing value!')
 
     def test_get_feature_names_out(self):
         for encoder_name in encoders.__all__:

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -307,7 +307,7 @@ class TestEncoders(TestCase):
                 enc = getattr(encoders, encoder_name)()
                 transformed = enc.fit_transform(x, y)
                 result = enc.inverse_transform(transformed)
-                self.assertTrue((x == result.values).all())
+                self.assertTrue((x == result.to_numpy()).all())
 
     def test_inverse_numpy(self):
         # See issue #196
@@ -357,7 +357,7 @@ class TestEncoders(TestCase):
 
                 encoder = getattr(encoders, encoder_name)()
                 result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
-                columns = result.columns.values
+                columns = result.columns
 
                 self.assertTrue('target' in columns[-1],
                                 "Target must be the last column as in the input. This is a tricky test because 'y' is named 'target' as well.")
@@ -384,7 +384,7 @@ class TestEncoders(TestCase):
             with self.subTest(encoder_name=encoder_name):
                 encoder = getattr(encoders, encoder_name)(cols=['feature'])
                 result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
-                columns = result.columns.values
+                columns = result.columns
 
                 self.assertTrue('ignore' in columns, "Column 'ignore' is missing in: " + str(columns))
 
@@ -442,13 +442,13 @@ class TestEncoders(TestCase):
     def test_string_index(self):
         train = pd.DataFrame({'city': ['chicago', 'denver']})
         target = [0, 1]
-        train.index = train.index.values.astype(str)
+        train.index = train.index.astype(str)
 
         for encoder_name in encoders.__all__:
             with self.subTest(encoder_name=encoder_name):
                 enc = getattr(encoders, encoder_name)()
                 result = enc.fit_transform(train, target)
-                self.assertFalse(result.isna().values.any(), 'There should not be any missing value!')
+                self.assertFalse(result.isna().any(axis=None), 'There should not be any missing value!')
 
     def test_get_feature_names_out(self):
         for encoder_name in encoders.__all__:
@@ -503,7 +503,7 @@ class TestEncoders(TestCase):
                 result = enc.fit_transform(data.x, data.y)
                 enc2 = getattr(encoders, encoder_name)()
                 result2 = enc2.fit_transform(data2.x, data2.y)
-                self.assertTrue((result.values == result2.values).all())
+                self.assertTrue((result.to_numpy() == result2.to_numpy()).all())
 
     def test_column_transformer(self):
         # see issue #169
@@ -620,31 +620,31 @@ class TestEncoders(TestCase):
 
                 enc3 = getattr(encoders, encoder_name)()
                 result3 = enc3.fit_transform(x3, y)
-                self.assertTrue((result1.values == result3.values).all())
+                self.assertTrue( (result1.to_numpy() == result3.to_numpy()).all() )
 
                 enc4 = getattr(encoders, encoder_name)()
                 result4 = enc4.fit_transform(x4, y)
-                self.assertTrue((result1.values == result4.values).all())
+                self.assertTrue(result1.equals(result4))
 
                 enc5 = getattr(encoders, encoder_name)()
                 result5 = enc5.fit_transform(x5, y)
-                self.assertTrue((result1.values == result5.values).all())
+                self.assertTrue(result1.equals(result5))
 
                 # gray encoder actually does re-order inputs
                 # rankhot encoder respects order, in this example the order is switched
                 if encoder_name not in ["GrayEncoder", "RankHotEncoder"]:
                     enc6 = getattr(encoders, encoder_name)()
                     result6 = enc6.fit_transform(x6, y)
-                    self.assertTrue((result1.values == result6.values).all())
+                    self.assertTrue(result1.equals(result6))
 
                 # Arguments
                 enc9 = getattr(encoders, encoder_name)(return_df=False)
                 result9 = enc9.fit_transform(x1, y)
-                self.assertTrue((result1.values == result9).all())
+                self.assertTrue((result1.to_numpy() == result9).all())
 
                 enc10 = getattr(encoders, encoder_name)(verbose=True)
                 result10 = enc10.fit_transform(x1, y)
-                self.assertTrue((result1.values == result10.values).all())
+                self.assertTrue(result1.equals(result10))
 
                 # Note: If the encoder does not support these arguments/argument values, it is OK/expected to fail.
                 # Note: The indicator approach is not tested because it adds columns -> the encoders that support it are expected to fail.
@@ -655,7 +655,7 @@ class TestEncoders(TestCase):
 
                 enc12 = getattr(encoders, encoder_name)(handle_unknown='value', handle_missing='value')
                 result12 = enc12.fit_transform(x1, y)
-                self.assertTrue((result1.values == result12.values).all(), 'The data do not contain any missing or new value -> the result should be unchanged.')
+                self.assertTrue(result1.equals(result12), 'The data do not contain any missing or new value -> the result should be unchanged.')
 
                 # enc13 = getattr(encoders, encoder_name)(handle_unknown='error', handle_missing='error', cols=['x'])  # Quite a few algorithms fail here because of handle_missing
                 # result13 = enc13.fit_transform(x3, y)

--- a/tests/test_helmert.py
+++ b/tests/test_helmert.py
@@ -17,7 +17,7 @@ class TestHelmertEncoder(TestCase):
         expected = [[1, -1, -1],
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_helmert_preserve_dimension_2(self):
         train = ['A', 'B', 'C']
@@ -30,7 +30,7 @@ class TestHelmertEncoder(TestCase):
         expected = [[1, 1, -1],
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_helmert_preserve_dimension_3(self):
         train = ['A', 'B', 'C']
@@ -44,7 +44,7 @@ class TestHelmertEncoder(TestCase):
                     [1, 1, -1],
                     [1, 0, 2],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_helmert_preserve_dimension_4(self):
         train = ['A', 'B', 'C']
@@ -58,7 +58,7 @@ class TestHelmertEncoder(TestCase):
                     [1, 1, -1],
                     [1, 0, 2],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_helmert_2cols(self):
         train = [['A', 'A'], ['B', 'B'], ['C', 'C']]
@@ -70,7 +70,7 @@ class TestHelmertEncoder(TestCase):
         expected = [[1, -1, -1, -1, -1],
                     [1,  1, -1,  1, -1],
                     [1,  0,  2,  0,  2]]
-        self.assertEqual(obtained.values.tolist(), expected)
+        self.assertEqual(obtained.to_numpy().tolist(), expected)
 
     def test_helmert_2StringCols_ExpectCorrectOrder(self):
         train = pd.DataFrame({'col1': [1, 2, 3, 4],
@@ -83,7 +83,7 @@ class TestHelmertEncoder(TestCase):
         encoder = encoders.HelmertEncoder(handle_unknown='value', handle_missing='value')
 
         encoder.fit(train)
-        columns = encoder.transform(train).columns.values
+        columns = encoder.transform(train).columns.to_numpy()
 
         self.assertTrue(np.array_equal(expected_columns, columns))
 
@@ -96,7 +96,7 @@ class TestHelmertEncoder(TestCase):
         expected = [[1, -1, -1],
                     [1, 1, -1],
                     [1, 0, 2]]
-        self.assertTrue(np.array_equal(result.values.tolist(), expected))
+        self.assertTrue(np.array_equal(result.to_numpy().tolist(), expected))
 
     def test_HandleMissingIndicator_HaveNoNan_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -106,7 +106,7 @@ class TestHelmertEncoder(TestCase):
 
         expected = [[1, -1, -1],
                     [1, 1, -1]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleMissingIndicator_NanNoNanInTrain_ExpectAsNanColumn(self):
         train = ['A', 'B']
@@ -119,7 +119,7 @@ class TestHelmertEncoder(TestCase):
         expected = [[1, -1, -1],
                     [1, 1, -1],
                     [1, 0, 2]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveNoUnknownInTrain_ExpectIndicatorInTest(self):
         train = ['A', 'B']
@@ -132,7 +132,7 @@ class TestHelmertEncoder(TestCase):
         expected = [[1, -1, -1],
                     [1, 1, -1],
                     [1, 0, 2]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveOnlyKnown_ExpectExtraColumn(self):
         train = ['A', 'B']
@@ -142,4 +142,4 @@ class TestHelmertEncoder(TestCase):
 
         expected = [[1, -1, -1],
                     [1, 1, -1]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)

--- a/tests/test_james_stein.py
+++ b/tests/test_james_stein.py
@@ -63,14 +63,14 @@ class TestJamesSteinEncoder(TestCase):
         X = np.array(['a', 'b', 'c'])
         y = np.array([1, 0, 1])
         out = encoders.JamesSteinEncoder(model='pooled').fit_transform(X, y)
-        self.assertTrue(all(np.var(out) == 0),
+        self.assertTrue(all(np.var(out, axis=0) == 0),
                           'This is not a standard behaviour of James-Stein estimator. But it helps a lot if we treat id-like attributes as non-predictive.')
 
     def test_ids_large_pooled(self):
         X = np.array(['a', 'b', 'c', 'd', 'e'])
         y = np.array([1, 0, 1, 0, 1])
         out = encoders.JamesSteinEncoder(model='pooled').fit_transform(X, y)
-        self.assertTrue(all(np.var(out) == 0),
+        self.assertTrue(all(np.var(out, axis=0) == 0),
                           'This is not a standard behaviour of James-Stein estimator. But it helps a lot if we treat id-like attributes as non-predictive.')
 
     # Beta
@@ -96,14 +96,14 @@ class TestJamesSteinEncoder(TestCase):
         X = np.array(['a', 'b', 'c'])
         y = np.array([1, 0, 1])
         out = encoders.JamesSteinEncoder(model='beta').fit_transform(X, y)
-        self.assertTrue(all(np.var(out) == 0),
+        self.assertTrue(all(np.var(out, axis=0) == 0),
                         'This is not a standard behaviour of James-Stein estimator. But it helps a lot if we treat id-like attributes as non-predictive.')
 
     def test_ids_large_beta(self):
         X = np.array(['a', 'b', 'c', 'd', 'e'])
         y = np.array([1, 0, 1, 0, 1])
         out = encoders.JamesSteinEncoder(model='beta').fit_transform(X, y)
-        self.assertTrue(all(np.var(out) == 0),
+        self.assertTrue(all(np.var(out, axis=0) == 0),
                         'This is not a standard behaviour of James-Stein estimator. But it helps a lot if we treat id-like attributes as non-predictive.')
 
     # Binary
@@ -126,12 +126,12 @@ class TestJamesSteinEncoder(TestCase):
         X = np.array(['a', 'b', 'c'])
         y = np.array([1, 0, 1])
         out = encoders.JamesSteinEncoder(model='binary').fit_transform(X, y)
-        self.assertTrue(all(np.var(out) == 0),
+        self.assertTrue(all(np.var(out, axis=0) == 0),
                           'This is not a standard behaviour of James-Stein estimator. But it helps a lot if we treat id-like attributes as non-predictive.')
 
     def test_identifiers_large_binary(self):
         X = np.array(['a', 'b', 'c', 'd', 'e'])
         y = np.array([1, 0, 1, 0, 1])
         out = encoders.JamesSteinEncoder(model='binary').fit_transform(X, y)
-        self.assertTrue(all(np.var(out) == 0),
+        self.assertTrue(all(np.var(out, axis=0) == 0),
                           'This is not a standard behaviour of James-Stein estimator. But it helps a lot if we treat id-like attributes as non-predictive.')

--- a/tests/test_leave_one_out.py
+++ b/tests/test_leave_one_out.py
@@ -55,7 +55,7 @@ class TestLeaveOneOutEncoder(TestCase):
         encoder = encoders.LeaveOneOutEncoder(handle_unknown='value')
         result = encoder.fit(X, y).transform(X, y)
 
-        self.assertFalse(result.isnull().any().any(), 'There should not be any missing value')
+        self.assertFalse(result.isna().any().any(), 'There should not be any missing value')
         expected = pd.DataFrame(data=[y.mean(), 0.5, 0, 0.5, y.mean()], columns=['col'])
         pd.testing.assert_frame_equal(expected, result)
 

--- a/tests/test_m_estimate.py
+++ b/tests/test_m_estimate.py
@@ -16,7 +16,7 @@ class TestMEstimateEncoder(TestCase):
         expected = [[1],
                     [0.5],
                     [3./4.]]  # The prior probability
-        self.assertEqual(scored.values.tolist(), expected)
+        self.assertEqual(scored.to_numpy().tolist(), expected)
 
     def test_reference_m1(self):
         x = ['A', 'A', 'B', 'B']
@@ -30,4 +30,4 @@ class TestMEstimateEncoder(TestCase):
         expected = [[(2+3./4.)/(2+1)],
                     [(1+3./4.)/(2+1)],
                     [3./4.]]  # The prior probability
-        self.assertEqual(scored.values.tolist(), expected)
+        self.assertEqual(scored.to_numpy().tolist(), expected)

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -20,12 +20,12 @@ class TestOneHotEncoderTestCase(TestCase):
         enc = encoders.OneHotEncoder(verbose=1, return_df=True, handle_unknown='indicator')
         enc.fit(X)
         out = enc.transform(X_t)
-        self.assertIn('extra_-1', out.columns.values)
+        self.assertIn('extra_-1', out.columns)
 
         enc = encoders.OneHotEncoder(verbose=1, return_df=True, handle_unknown='return_nan')
         enc.fit(X)
         out = enc.transform(X_t)
-        self.assertEqual(len([x for x in out.columns.values if str(x).startswith('extra_')]), 3)
+        self.assertEqual(len([x for x in out.columns if str(x).startswith('extra_')]), 3)
 
         enc = encoders.OneHotEncoder(verbose=1, return_df=True, handle_unknown='error')
         # The exception is already raised in fit() because transform() is called there to get
@@ -37,12 +37,12 @@ class TestOneHotEncoderTestCase(TestCase):
         enc = encoders.OneHotEncoder(verbose=1, return_df=True, handle_unknown='return_nan', use_cat_names=True)
         enc.fit(X)
         out = enc.transform(X_t)
-        self.assertIn('extra_A', out.columns.values)
+        self.assertIn('extra_A', out.columns)
 
         enc = encoders.OneHotEncoder(verbose=1, return_df=True, use_cat_names=True, handle_unknown='indicator')
         enc.fit(X)
         out = enc.transform(X_t)
-        self.assertIn('extra_-1', out.columns.values)
+        self.assertIn('extra_-1', out.columns)
 
         # test inverse_transform
         X_i = th.create_dataset(n_rows=100, has_missing=False)
@@ -145,7 +145,7 @@ class TestOneHotEncoderTestCase(TestCase):
         expected = [[1, 0],
                     [0, 1],
                     [0, 1]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
         self.assertRaisesRegex(ValueError, '.*null.*', encoder.transform, data_w_missing)
 
@@ -201,7 +201,7 @@ class TestOneHotEncoderTestCase(TestCase):
         expected = [[1, 0, 0],
                     [0, 1, 0],
                     [0, 0, 1]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleMissingIndicator_HaveNoNan_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -211,7 +211,7 @@ class TestOneHotEncoderTestCase(TestCase):
 
         expected = [[1, 0, 0],
                     [0, 1, 0]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleMissingIndicator_NanNoNanInTrain_ExpectAsNanColumn(self):
         train = ['A', 'B']
@@ -223,12 +223,12 @@ class TestOneHotEncoderTestCase(TestCase):
 
         expected_1 = [[1, 0, 0],
                       [0, 1, 0]]
-        self.assertEqual(encoded_train.values.tolist(), expected_1)
+        self.assertEqual(encoded_train.to_numpy().tolist(), expected_1)
 
         expected_2 = [[1, 0, 0],
                       [0, 1, 0],
                       [0, 0, 1]]
-        self.assertEqual(encoded_test.values.tolist(), expected_2)
+        self.assertEqual(encoded_test.to_numpy().tolist(), expected_2)
 
     def test_HandleUnknown_HaveNoUnknownInTrain_ExpectIndicatorInTest(self):
         train = ['A', 'B']
@@ -241,7 +241,7 @@ class TestOneHotEncoderTestCase(TestCase):
         expected = [[1, 0, 0],
                     [0, 1, 0],
                     [0, 0, 1]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveOnlyKnown_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -251,7 +251,7 @@ class TestOneHotEncoderTestCase(TestCase):
 
         expected = [[1, 0, 0],
                     [0, 1, 0]]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_inverse_transform_HaveNanInTrainAndHandleMissingValue_ExpectReturnedWithNan(self):
         train = pd.DataFrame({'city': ['chicago', np.nan]})

--- a/tests/test_ordinal.py
+++ b/tests/test_ordinal.py
@@ -46,7 +46,7 @@ class TestOrdinalEncoder(TestCase):
         result = encoder.fit_transform(data)
         self.assertEqual(2, len(result[0].unique()), "We expect two unique values in the column")
         self.assertEqual(2, len(result[1].unique()), "We expect two unique values in the column")
-        self.assertFalse(np.isnan(result.values[1, 1]))
+        self.assertFalse(np.isnan(result.iloc[1, 1]))
 
         encoder = encoders.OrdinalEncoder(handle_missing="return_nan")
         result = encoder.fit_transform(data)

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -22,7 +22,7 @@ class TestPolynomialEncoder(TestCase):
         expected = [a_encoding,
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(deep_round(test_t.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(test_t.to_numpy().tolist()), deep_round(expected))
 
     def test_polynomial_encoder_preserve_dimension_2(self):
         train = ['A', 'B', 'C']
@@ -35,7 +35,7 @@ class TestPolynomialEncoder(TestCase):
         expected = [b_encoding,
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(deep_round(test_t.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(test_t.to_numpy().tolist()), deep_round(expected))
 
     def test_polynomial_encoder_preserve_dimension_3(self):
         train = ['A', 'B', 'C']
@@ -49,7 +49,7 @@ class TestPolynomialEncoder(TestCase):
                     b_encoding,
                     c_encoding,
                     [1, 0, 0]]
-        self.assertEqual(deep_round(test_t.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(test_t.to_numpy().tolist()), deep_round(expected))
 
     def test_polynomial_encoder_preserve_dimension_4(self):
         train = ['A', 'B', 'C']
@@ -63,7 +63,7 @@ class TestPolynomialEncoder(TestCase):
                     b_encoding,
                     c_encoding,
                     [1, 0, 0]]
-        self.assertEqual(deep_round(test_t.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(test_t.to_numpy().tolist()), deep_round(expected))
 
     def test_polynomial_encoder_2cols(self):
         train = [['A', 'A'], ['B', 'B'], ['C', 'C']]
@@ -75,7 +75,7 @@ class TestPolynomialEncoder(TestCase):
         expected = [[1, a_encoding[1], a_encoding[2], a_encoding[1], a_encoding[2]],
                     [1, b_encoding[1], b_encoding[2], b_encoding[1], b_encoding[2]],
                     [1, c_encoding[1], c_encoding[2], c_encoding[1], c_encoding[2]]]
-        self.assertEqual(deep_round(obtained.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(obtained.to_numpy().tolist()), deep_round(expected))
 
     def test_polynomial_encoder_2StringCols_ExpectCorrectOrder(self):
         train = pd.DataFrame({'col1': [1, 2, 3, 4],
@@ -88,7 +88,7 @@ class TestPolynomialEncoder(TestCase):
         encoder = encoders.PolynomialEncoder(handle_unknown='value', handle_missing='value')
 
         encoder.fit(train)
-        columns = encoder.transform(train).columns.values
+        columns = encoder.transform(train).columns.to_numpy()
 
         self.assertTrue(np.array_equal(expected_columns, columns))
 
@@ -101,7 +101,7 @@ class TestPolynomialEncoder(TestCase):
         expected = [a_encoding,
                     b_encoding,
                     c_encoding]
-        self.assertTrue(np.array_equal(deep_round(result.values.tolist()), deep_round(expected)))
+        self.assertTrue(np.array_equal(deep_round(result.to_numpy().tolist()), deep_round(expected)))
 
     def test_HandleMissingIndicator_HaveNoNan_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -111,7 +111,7 @@ class TestPolynomialEncoder(TestCase):
 
         expected = [a_encoding,
                     b_encoding]
-        self.assertEqual(deep_round(result.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(result.to_numpy().tolist()), deep_round(expected))
 
     def test_HandleMissingIndicator_NanNoNanInTrain_ExpectAsNanColumn(self):
         train = ['A', 'B']
@@ -124,7 +124,7 @@ class TestPolynomialEncoder(TestCase):
         expected = [a_encoding,
                     b_encoding,
                     c_encoding]
-        self.assertEqual(deep_round(result.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(result.to_numpy().tolist()), deep_round(expected))
 
     def test_HandleUnknown_HaveNoUnknownInTrain_ExpectIndicatorInTest(self):
         train = ['A', 'B']
@@ -137,7 +137,7 @@ class TestPolynomialEncoder(TestCase):
         expected = [a_encoding,
                     b_encoding,
                     c_encoding]
-        self.assertEqual(deep_round(result.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(result.to_numpy().tolist()), deep_round(expected))
 
     def test_HandleUnknown_HaveOnlyKnown_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -147,4 +147,4 @@ class TestPolynomialEncoder(TestCase):
 
         expected = [a_encoding,
                     b_encoding]
-        self.assertEqual(deep_round(result.values.tolist()), deep_round(expected))
+        self.assertEqual(deep_round(result.to_numpy().tolist()), deep_round(expected))

--- a/tests/test_sum_coding.py
+++ b/tests/test_sum_coding.py
@@ -21,7 +21,7 @@ class TestSumEncoder(TestCase):
         expected = [a_encoding,
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_sum_encoder_preserve_dimension_2(self):
         train = ['A', 'B', 'C']
@@ -34,7 +34,7 @@ class TestSumEncoder(TestCase):
         expected = [b_encoding,
                     [1, 0, 0],
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_sum_encoder_preserve_dimension_3(self):
         train = ['A', 'B', 'C']
@@ -48,7 +48,7 @@ class TestSumEncoder(TestCase):
                     b_encoding,
                     c_encoding,
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_sum_encoder_preserve_dimension_4(self):
         train = ['A', 'B', 'C']
@@ -62,7 +62,7 @@ class TestSumEncoder(TestCase):
                     b_encoding,
                     c_encoding,
                     [1, 0, 0]]
-        self.assertEqual(test_t.values.tolist(), expected)
+        self.assertEqual(test_t.to_numpy().tolist(), expected)
 
     def test_sum_encoder_2cols(self):
         train = [['A', 'A'], ['B', 'B'], ['C', 'C']]
@@ -74,7 +74,7 @@ class TestSumEncoder(TestCase):
         expected = [[1, a_encoding[1], a_encoding[2], a_encoding[1], a_encoding[2]],
                     [1, b_encoding[1], b_encoding[2], b_encoding[1], b_encoding[2]],
                     [1, c_encoding[1], c_encoding[2], c_encoding[1], c_encoding[2]]]
-        self.assertEqual(obtained.values.tolist(), expected)
+        self.assertEqual(obtained.to_numpy().tolist(), expected)
 
     def test_sum_encoder_2StringCols_ExpectCorrectOrder(self):
         train = pd.DataFrame({'col1': [1, 2, 3, 4],
@@ -87,7 +87,7 @@ class TestSumEncoder(TestCase):
         encoder = encoders.SumEncoder(handle_unknown='value', handle_missing='value')
 
         encoder.fit(train)
-        columns = encoder.transform(train).columns.values
+        columns = encoder.transform(train).columns.to_numpy()
 
         self.assertTrue(np.array_equal(expected_columns, columns))
 
@@ -100,7 +100,7 @@ class TestSumEncoder(TestCase):
         expected = [a_encoding,
                     b_encoding,
                     c_encoding]
-        self.assertTrue(np.array_equal(result.values.tolist(), expected))
+        self.assertTrue(np.array_equal(result.to_numpy().tolist(), expected))
 
     def test_HandleMissingIndicator_HaveNoNan_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -110,7 +110,7 @@ class TestSumEncoder(TestCase):
 
         expected = [a_encoding,
                     b_encoding]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleMissingIndicator_NanNoNanInTrain_ExpectAsNanColumn(self):
         train = ['A', 'B']
@@ -123,7 +123,7 @@ class TestSumEncoder(TestCase):
         expected = [a_encoding,
                     b_encoding,
                     c_encoding]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveNoUnknownInTrain_ExpectIndicatorInTest(self):
         train = ['A', 'B']
@@ -136,7 +136,7 @@ class TestSumEncoder(TestCase):
         expected = [a_encoding,
                     b_encoding,
                     c_encoding]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)
 
     def test_HandleUnknown_HaveOnlyKnown_ExpectSecondColumn(self):
         train = ['A', 'B']
@@ -146,4 +146,4 @@ class TestSumEncoder(TestCase):
 
         expected = [a_encoding,
                     b_encoding]
-        self.assertEqual(result.values.tolist(), expected)
+        self.assertEqual(result.to_numpy().tolist(), expected)

--- a/tests/test_target_encoder.py
+++ b/tests/test_target_encoder.py
@@ -74,7 +74,7 @@ class TestTargetEncoder(TestCase):
              'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
         encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
         result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
-        values = result['Trend'].values
+        values = result['Trend'].array
         self.assertAlmostEqual(0.5874, values[0], delta=1e-4)
         self.assertAlmostEqual(0.5874, values[1], delta=1e-4)
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
@@ -89,7 +89,7 @@ class TestTargetEncoder(TestCase):
              'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
         encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
         result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
-        values = result['Trend'].values
+        values = result['Trend'].array
         self.assertAlmostEqual(0.5874, values[0], delta=1e-4)
         self.assertAlmostEqual(0.5874, values[1], delta=1e-4)
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
@@ -103,7 +103,7 @@ class TestTargetEncoder(TestCase):
              'target': [1, 1, 0, 0, 1, 0, 0, 0, 1, 1]})
         encoder = encoders.TargetEncoder(cols=['Trend'], min_samples_leaf=k, smoothing=f)
         result = encoder.fit_transform(binary_cat_example, binary_cat_example['target'])
-        values = result['Trend'].values
+        values = result['Trend'].array
         self.assertAlmostEqual(0.5874, values[0], delta=1e-4)
         self.assertAlmostEqual(0.5874, values[1], delta=1e-4)
         self.assertAlmostEqual(0.4125, values[2], delta=1e-4)
@@ -141,7 +141,7 @@ class TestTargetEncoder(TestCase):
 
         enc = encoders.TargetEncoder(verbose=1, smoothing=2, min_samples_leaf=2, hierarchy=self.hierarchical_map, cols=['Compass'])
         result = enc.fit_transform(self.hierarchical_cat_example, self.hierarchical_cat_example['target'])
-        values = result['Compass'].values
+        values = result['Compass'].array
         self.assertAlmostEqual(0.6226, values[0], delta=1e-4)
         self.assertAlmostEqual(0.9038, values[2], delta=1e-4)
         self.assertAlmostEqual(0.1766, values[5], delta=1e-4)
@@ -153,19 +153,19 @@ class TestTargetEncoder(TestCase):
         enc = encoders.TargetEncoder(verbose=1, smoothing=2, min_samples_leaf=2, hierarchy=self.hierarchical_map, cols=['Compass', 'Speed', 'Animal'])
         result = enc.fit_transform(self.hierarchical_cat_example, self.hierarchical_cat_example['target'])
 
-        values = result['Compass'].values
+        values = result['Compass'].array
         self.assertAlmostEqual(0.6226, values[0], delta=1e-4)
         self.assertAlmostEqual(0.9038, values[2], delta=1e-4)
         self.assertAlmostEqual(0.1766, values[5], delta=1e-4)
         self.assertAlmostEqual(0.4605, values[7], delta=1e-4)
         self.assertAlmostEqual(0.4033, values[11], delta=1e-4)
 
-        values = result['Speed'].values
+        values = result['Speed'].array
         self.assertAlmostEqual(0.6827, values[0], delta=1e-4)
         self.assertAlmostEqual(0.3962, values[4], delta=1e-4)
         self.assertAlmostEqual(0.4460, values[7], delta=1e-4)
 
-        values = result['Animal'].values
+        values = result['Animal'].array
         self.assertAlmostEqual(0.7887, values[0], delta=1e-4)
         self.assertAlmostEqual(0.3248, values[5], delta=1e-4)
         self.assertAlmostEqual(0.6190, values[11], delta=1e-4)
@@ -177,14 +177,14 @@ class TestTargetEncoder(TestCase):
         enc = encoders.TargetEncoder(verbose=1, smoothing=2, min_samples_leaf=2, hierarchy=self.hierarchical_map, cols=['Compass'])
         result = enc.fit_transform(self.hierarchical_cat_example, self.hierarchical_cat_example['target'])
 
-        values = result['Compass'].values
+        values = result['Compass'].array
         self.assertAlmostEqual(0.6226, values[0], delta=1e-4)
         self.assertAlmostEqual(0.9038, values[2], delta=1e-4)
         self.assertAlmostEqual(0.1766, values[5], delta=1e-4)
         self.assertAlmostEqual(0.4605, values[7], delta=1e-4)
         self.assertAlmostEqual(0.4033, values[11], delta=1e-4)
 
-        values = result['Speed'].values
+        values = result['Speed'].array
         self.assertEqual('slow', values[0])
 
     def test_hierarchy_pandas_index(self):
@@ -204,7 +204,7 @@ class TestTargetEncoder(TestCase):
         enc = encoders.TargetEncoder(verbose=1, smoothing=2, min_samples_leaf=2, hierarchy=self.hierarchical_map, cols=cols)
         result = enc.fit_transform(df, df['world'])
 
-        values = result['hello'].values
+        values = result['hello'].array
         self.assertAlmostEqual(0.3616, values[0], delta=1e-4)
         self.assertAlmostEqual(0.4541, values[1], delta=1e-4)
         self.assertAlmostEqual(0.2425, values[2], delta=1e-4)
@@ -216,7 +216,7 @@ class TestTargetEncoder(TestCase):
                                      cols=['Plant'])
         result = enc.fit_transform(self.hierarchical_cat_example, self.hierarchical_cat_example['target'])
 
-        values = result['Plant'].values
+        values = result['Plant'].array
         self.assertAlmostEqual(0.6828, values[0], delta=1e-4)
         self.assertAlmostEqual(0.5, values[4], delta=1e-4)
         self.assertAlmostEqual(0.5, values[8], delta=1e-4)
@@ -236,7 +236,7 @@ class TestTargetEncoder(TestCase):
                                      cols=['Plant'])
         result = enc.fit_transform(self.hierarchical_cat_example, self.hierarchical_cat_example['target'])
 
-        values = result['Plant'].values
+        values = result['Plant'].array
         self.assertAlmostEqual(0.6828, values[0], delta=1e-4)
         self.assertAlmostEqual(0.5, values[4], delta=1e-4)
         self.assertAlmostEqual(0.5, values[8], delta=1e-4)
@@ -291,7 +291,7 @@ class TestTargetEncoder(TestCase):
                                      cols=['Animal'])
         result = enc.fit_transform(hierarchy_multi_level_df, hierarchy_multi_level_df['target'])
 
-        values = result['Animal'].values
+        values = result['Animal'].array
         self.assertAlmostEqual(0.6261, values[0], delta=1e-4)
         self.assertAlmostEqual(0.9065, values[2], delta=1e-4)
         self.assertAlmostEqual(0.2556, values[5], delta=1e-4)
@@ -308,7 +308,7 @@ class TestTargetEncoder(TestCase):
                                      cols=['compass'])
         result = enc.fit_transform(X[cols], y)
 
-        values = result['compass'].values
+        values = result['compass'].array
         self.assertAlmostEqual(0.6226, values[0], delta=1e-4)
         self.assertAlmostEqual(0.9038, values[2], delta=1e-4)
         self.assertAlmostEqual(0.1766, values[5], delta=1e-4)
@@ -324,7 +324,7 @@ class TestTargetEncoder(TestCase):
                                      cols=['postcode'])
         result = enc.fit_transform(X[cols], y)
 
-        values = result['postcode'].values
+        values = result['postcode'].array
         self.assertAlmostEqual(0.8448, values[0], delta=1e-4)
 
 

--- a/tests/test_woe.py
+++ b/tests/test_woe.py
@@ -99,13 +99,13 @@ class TestWeightOfEvidenceEncoder(TestCase):
         enc.fit(X, np_y)
         X1 = enc.transform(X_t)
         th.verify_numeric(X1)
-        self.assertTrue(X1.isnull().values.any())
+        self.assertTrue(X1.isna().values.any())
         self.assertEqual(len(list(X_t)), len(list(X1)), 'The count of attributes must not change')
         self.assertEqual(len(X_t), len(X1), 'The count of rows must not change')
 
         X2 = enc.transform(X_t, np_y_t)
         th.verify_numeric(X2)
-        self.assertTrue(X1.isnull().values.any())
+        self.assertTrue(X1.isna().values.any())
         self.assertEqual(len(list(X_t)), len(list(X2)), 'The count of attributes must not change')
         self.assertEqual(len(X_t), len(X2), 'The count of rows must not change')
 

--- a/tests/test_woe.py
+++ b/tests/test_woe.py
@@ -32,26 +32,26 @@ class TestWeightOfEvidenceEncoder(TestCase):
         enc.fit(X, np_y)
         X1 = enc.transform(X_t)
         th.verify_numeric(X1[cols])
-        self.assertTrue(np.isfinite(X1[cols].values).all(),
+        self.assertTrue(np.isfinite(X1[cols].to_numpy()).all(),
                         'There must not be any NaN, inf or -inf in the transformed columns')
         self.assertEqual(len(list(X_t)), len(list(X1)), 'The count of attributes must not change')
         self.assertEqual(len(X_t), len(X1), 'The count of rows must not change')
         X2 = enc.transform(X_t, np_y_t)
         th.verify_numeric(X2)
-        self.assertTrue(np.isfinite(X2[cols].values).all(),
+        self.assertTrue(np.isfinite(X2[cols].to_numpy()).all(),
                         'There must not be any NaN, inf or -inf in the transformed columns')
         self.assertEqual(len(list(X_t)), len(list(X2)), 'The count of attributes must not change')
         self.assertEqual(len(X_t), len(X2), 'The count of rows must not change')
         X3 = enc.transform(X, np_y)
         th.verify_numeric(X3)
-        self.assertTrue(np.isfinite(X3[cols].values).all(),
+        self.assertTrue(np.isfinite(X3[cols].to_numpy()).all(),
                         'There must not be any NaN, inf or -inf in the transformed columns')
         self.assertEqual(len(list(X)), len(list(X3)), 'The count of attributes must not change')
         self.assertEqual(len(X), len(X3), 'The count of rows must not change')
         self.assertTrue(X3['unique_str'].var() < 0.001, 'The unique string column must not be predictive of the label')
         X4 = enc.fit_transform(X, np_y)
         th.verify_numeric(X4)
-        self.assertTrue(np.isfinite(X4[cols].values).all(),
+        self.assertTrue(np.isfinite(X4[cols].to_numpy()).all(),
                         'There must not be any NaN, inf or -inf in the transformed columns')
         self.assertEqual(len(list(X)), len(list(X4)), 'The count of attributes must not change')
         self.assertEqual(len(X), len(X4), 'The count of rows must not change')
@@ -99,13 +99,13 @@ class TestWeightOfEvidenceEncoder(TestCase):
         enc.fit(X, np_y)
         X1 = enc.transform(X_t)
         th.verify_numeric(X1)
-        self.assertTrue(X1.isna().values.any())
+        self.assertTrue(X1.isna().any(axis=None))
         self.assertEqual(len(list(X_t)), len(list(X1)), 'The count of attributes must not change')
         self.assertEqual(len(X_t), len(X1), 'The count of rows must not change')
 
         X2 = enc.transform(X_t, np_y_t)
         th.verify_numeric(X2)
-        self.assertTrue(X1.isna().values.any())
+        self.assertTrue(X1.isna().any(axis=None))
         self.assertEqual(len(list(X_t)), len(list(X2)), 'The count of attributes must not change')
         self.assertEqual(len(X_t), len(X2), 'The count of rows must not change')
 

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -35,7 +35,7 @@ class TestMultiClassWrapper(TestCase):
         wrapper = PolynomialWrapper(encoders.TargetEncoder())
         result2 = wrapper.fit_transform(x, y)
 
-        self.assertTrue((result.values == result2.values).all(), 'The content should be the same regardless whether we pass Numpy or Pandas data type.')
+        self.assertTrue((result.to_numpy() == result2.to_numpy()).all(), 'The content should be the same regardless whether we pass Numpy or Pandas data type.')
 
     def test_transform_only_selected(self):
         x = pd.DataFrame([


### PR DESCRIPTION
(On top of previous commit regarding `inplace`.)

Most of these changes are simply replacing `.values` with either `.array` or `.to_numpy()`.
The reason `.values` is discouraged, is because it behaves somewhat inconsistently.
- I believe `DataFrame.values` always results a numpy array.
- `Series.values` may return other types of pandas array, such as `pyarrow` arrays.

I've tried to be more explicit, and use `.to_numpy()` whenever the object really needs to be numpy type.

P.S. You can probably ignore these changes if you don't feel comfortable with them, I believe they mostly have no functional impact. The only real useful change is adding `axis=0` to some instances of `np.var()` in the tests. They're going to change the default to `axis=None` in some future version of numpy, which make break those tests.