### PR TITLE
Optimise `HashingEncoder` for both large and small dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 unreleased
 ==========
+* improved: performance of the hashing encoder (about twice as fast)
+  * deprecate the `max_sample`` parameter, it has no use anymore
+  * add `process_creation_method` parameter
+  * use concurrent.futures.ProcessPoolExecutor instead of hand-managed queues
+  * optimisations to hashlib calls, remove python 2 checks, fork instead of spawn
 
 v2.6.2
 ======

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -175,12 +175,9 @@ class HashingEncoder(util.BaseEncoder, util.UnsupervisedTransformerMixin):
         for i, row in enumerate(np_df):
             for val in row:
                 if val is not None:
-                    hasher = hashlib.new('md5')
-                    if sys.version_info[0] == 2:
-                        hasher.update(str(val))
-                    else:
-                        hasher.update(bytes(str(val), 'utf-8'))
-                    column_index = int(hasher.hexdigest(), 16) % N
+                    hasher = hashlib.md5()
+                    hasher.update(bytes(str(val), 'utf-8'))
+                    column_index = int.from_bytes(hasher.digest(), byteorder='big') % N
                     row_index = (shm_offset + i)*N
                     shm_index = row_index + column_index
                     shm_result[shm_index] += 1

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -42,3 +42,17 @@ class TestHashingEncoder(TestCase):
                          set(target_columns))
                    ) == df_encoded_multi_process.shape[1]
                )
+
+    def test_simple_example(self):
+        df = pd.DataFrame({
+         'strings': ["aaaa", "bbbb", "cccc"],
+         "more_strings": ["aaaa", "dddd", "eeee"],
+        })
+        encoder = encoders.HashingEncoder(n_components=4, max_process=2)
+        encoder.fit(df)
+        assert encoder.transform(df).equals(pd.DataFrame({
+            "col_0": [0,1,1],
+            "col_1": [2,0,1],
+            "col_2": [0,1,0],
+            "col_3": [0,0,0]
+        }))


### PR DESCRIPTION
I used the HashingEncoder recently and found weird that any call to `fit` or `transform`, even for a dataframe with only 10s of rows and a couple of columns took at least 2s... 

I also had quite a large amount of data to encode, and that took a long time. 

That got me started on improving the performance of HashingEncoder, and here's the result! There are quite a few changes in there, each individual change should be in it's own commit, and here's a summary of the performance gain on my machine (macOS Monteray, i7 2.3ghz). 

|  | Baseline | Numpy arrays instead of apply | Shared memory instead of queue | Fork instead of spawn | Faster hashlib usage |
| --- | --- | --- | --- | --- | --- |
| n_rows=30 n_features=3 n_components=10 n_process=4 | 3.55 s ± 150 ms per loop (mean ± std. dev. of ... | 3.62 s ± 140 ms per loop (mean ± std. dev. of ... | 2.2 s ± 41.6 ms per loop (mean ± std. dev. of ... | 56.6 ms ± 2.91 ms per loop (mean ± std. dev. o... | 47.3 ms ± 516 µs per loop (mean ± std. dev. of... |
| n_rows=30 n_features=3 n_components=10 n_process=1 | 1.24 s ± 52.6 ms per loop (mean ± std. dev. of... | 1.42 s ± 170 ms per loop (mean ± std. dev. of ... | 1.74 ms ± 32.2 µs per loop (mean ± std. dev. o... | 2.08 ms ± 91.7 µs per loop (mean ± std. dev. o... | 1.86 ms ± 173 µs per loop (mean ± std. dev. of... |
| n_rows=30 n_features=3 n_components=100 n_process=1 | 1.22 s ± 51.5 ms per loop (mean ± std. dev. of... | 1.33 s ± 60.7 ms per loop (mean ± std. dev. of... | 1.73 ms ± 29.7 µs per loop (mean ± std. dev. o... | 2.01 ms ± 148 µs per loop (mean ± std. dev. of... | 2.01 ms ± 225 µs per loop (mean ± std. dev. of... |
| n_rows=10000 n_features=10 n_components=10 n_process=4 | 5.45 s ± 85.8 ms per loop (mean ± std. dev. of... | 5.36 s ± 57.5 ms per loop (mean ± std. dev. of... | 2.23 s ± 39.6 ms per loop (mean ± std. dev. of... | 120 ms ± 3.02 ms per loop (mean ± std. dev. of... | 96.4 ms ± 2.33 ms per loop (mean ± std. dev. o... |
| n_rows=10000 n_features=10 n_components=10 n_process=1 | 1.61 s ± 30.1 ms per loop (mean ± std. dev. of... | 1.45 s ± 27.2 ms per loop (mean ± std. dev. of... | 227 ms ± 6.03 ms per loop (mean ± std. dev. of... | 236 ms ± 3.06 ms per loop (mean ± std. dev. of... | 170 ms ± 1.35 ms per loop (mean ± std. dev. of... |
| n_rows=100000 n_features=10 n_components=10 n_process=4 | 5.99 s ± 215 ms per loop (mean ± std. dev. of ... | 5.71 s ± 148 ms per loop (mean ± std. dev. of ... | 4.8 s ± 25.4 ms per loop (mean ± std. dev. of ... | 836 ms ± 42.3 ms per loop (mean ± std. dev. of... | 622 ms ± 33.2 ms per loop (mean ± std. dev. of... |
| n_rows=100000 n_features=10 n_components=10 n_process=1 | 5.38 s ± 53 ms per loop (mean ± std. dev. of 7... | 3.73 s ± 56.5 ms per loop (mean ± std. dev. of... | 2.25 s ± 57.4 ms per loop (mean ± std. dev. of... | 3.76 s ± 1.61 s per loop (mean ± std. dev. of ... | 1.68 s ± 19.9 ms per loop (mean ± std. dev. of... |
| n_rows=1000000 n_features=50 n_components=10 n_process=4 | 50.8 s ± 1.17 s per loop (mean ± std. dev. of ... | 56.4 s ± 2.11 s per loop (mean ± std. dev. of ... | 37.1 s ± 576 ms per loop (mean ± std. dev. of ... | 36.9 s ± 2.19 s per loop (mean ± std. dev. of ... | 26.6 s ± 1.8 s per loop (mean ± std. dev. of 7... |
| n_rows=1000000 n_features=50 n_components=10 n_process=1 | 2min 22s ± 2.05 s per loop (mean ± std. dev. o... | 2min 19s ± 3.08 s per loop (mean ± std. dev. o... | 1min 47s ± 1.15 s per loop (mean ± std. dev. o... | 2min 10s ± 18.4 s per loop (mean ± std. dev. o... | 1min 21s ± 1.67 s per loop (mean ± std. dev. o... |

The notebook that produced that table can be found [here](https://gist.github.com/bkhant1/ae2b813817d53b19a81f6774234fcfe3) 

## Proposed Changes

The changes are listed by commit.

### [Add a simple non-regression HashEncoder test](https://github.com/scikit-learn-contrib/category_encoders/commit/0afe06586c71388b8fd4034d196de8a7df4ad56c) 

To make sure I am not breaking it.

### [In HashingEncoder process the df as a numpy array instead of using apply](https://github.com/scikit-learn-contrib/category_encoders/commit/de124410f29778487a2910c8dd7f15ed15785705)

It has no direct impact on performance, however it allows accessing the memory layout of the dataframe directly. That allows using shared memory to communicate between processes instead of a data queue, which does improve performance. 

### [In HashEncoder use shared memory instead of queue for multiproccessing](https://github.com/scikit-learn-contrib/category_encoders/commit/5235a6b85e787b3a384c0d43f314c0e3146d3daf)

It is faster to write directly in memory that to have to data transit through a queue.

The multiprocessing method is similar to what it was with queues: the dataframe is split into chunks, and each process applies the hashing trick to its chunk of the dataframe. Instead of writting the result to a queue, it writes it directly in a shared memory segment, that is also the underlying memory of a numpy array that is used to build the output dataframe.

### [Allow forking processes instead of spwaning them and make it default](https://github.com/scikit-learn-contrib/category_encoders/commit/12f8f242959314ed770750902c1e5ab8ca81263e)

This makes the HashEncoder transform method a lot faster on small datasets.

The spawn process creation method creates a new python interpreter from scratch, and re-import all required module. In a minimal case (pandas and category_encoders.hashing only are imported) this adds a ~2s overhead to any call to transform.

Fork creates a copy of the current process, and that's it. It is unsafe to use with threads, locks, file descriptors, ... but in that case the only thing the forked process will do is process some data and write it to ITS OWN segment of a shared memory. It is a lot faster as pandas doesn't have to be re-imported (around 20ms?)

It might take up more memory as more than the necessary variables (the largest one by far being the HashEncoder instance, which include the user dataframe) will be copied. Add the option to use spawn instead of fork to potentially save some memory.

### [Remove python 2 check code and faster use of hashlib](https://github.com/scikit-learn-contrib/category_encoders/commit/d2d535b4b8b2c54adcb9b13a6b06b5fc8c55286c)

Python 2 is not supported on master, the check isn't useful.

Create int indexes from hashlib bytes digest instead of hex digest as it's faster.

Call the md5 hashlib constructor directly instead of new('md5'), which is also faster.


