### PR TITLE
Fixed the DataFrame conversion of y in PolynomialWrapper's fit method

### DIFF
--- a/category_encoders/wrapper.py
+++ b/category_encoders/wrapper.py
@@ -78,7 +78,7 @@ class PolynomialWrapper(BaseEstimator, TransformerMixin):
     def fit(self, X, y, **kwargs):
         # unite the input into pandas types
         X, y = utils.convert_inputs(X, y)
-        y = pd.DataFrame(y, columns=['target'])
+        y = pd.DataFrame(y.rename('target'))
 
         # apply one-hot-encoder on the label
         self.label_encoder = encoders.OneHotEncoder(handle_missing='error',


### PR DESCRIPTION
Fixes #

## Proposed Changes
Changed from y = pd.DataFrame(y, columns=['target']) to y = pd.DataFrame(y.rename('target')).
This is because if the original y is a pd.Series with a name other than 'target', pd.DataFrame(y, columns=['target']) returns an empty DataFrame.

The root cause of this problem is that in the function of utils.convert_input_vector(y, index) -> pd.Series, when a pd.Series or a single-column pd.DataFrame is passed as an argument, the process is designed to inherit the column name from the column name of the passed pd.Series or pd.DataFrame.