### PR TITLE
Fix for sklearn-pandas-out and refit

### DIFF
--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -320,6 +320,7 @@ class BaseEncoder(BaseEstimator):
         self._fit(X, y, **kwargs)
 
         # for finding invariant columns transform without y (as is done on the test set)
+        self.feature_names_out_ = None  # Issue#437
         X_transformed = self.transform(X, override_return_df=True)
         self.feature_names_out_ = X_transformed.columns.tolist()
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx_rtd_theme
 pytest
 numpydoc
+packaging

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
 from unittest import TestCase  # or `from unittest import ...` if on Python 3.4+
+import pytest
 from category_encoders.utils import convert_input_vector, convert_inputs, get_categorical_cols, BaseEncoder
+
 from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn import __version__ as skl_version
+from packaging.version import Version
 import pandas as pd
 import numpy as np
 
@@ -134,6 +138,7 @@ class TestBaseEncoder(TestCase):
 
         self.encoder = DummyEncoder()
 
+    @pytest.mark.skipif(Version(skl_version) < Version('1.2'), reason="requires sklean > 1.2")
     def test_sklearn_pandas_out_refit(self):
         # Thanks to Issue#437
         df = pd.DataFrame({"C1": ["a", "a"], "C2": ["c", "d"]})


### PR DESCRIPTION
Fixes #437

## Proposed Changes
Resets `feature_names_out_` before applying `transform` (in case the latter uses the former, as when sklearn is set to pandas-output).