### PR TITLE
Change apposed to opposed in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,7 +77,7 @@ the cols parameter isn't passed, every non-numeric column will be converted. See
 Known issues:
 -------------
 
-`CategoryEncoders` internally works with `pandas DataFrames` as apposed to `sklearn` which works with `numpy arrays`. This can cause problems in `sklearn` versions prior to 1.2.0. In order to ensure full compatibility with `sklearn` set `sklearn` to also output `DataFrames`. This can be done by
+`CategoryEncoders` internally works with `pandas DataFrames` as opposed to `sklearn` which works with `numpy arrays`. This can cause problems in `sklearn` versions prior to 1.2.0. In order to ensure full compatibility with `sklearn` set `sklearn` to also output `DataFrames`. This can be done by
 
 .. code-block:: python
 


### PR DESCRIPTION
## Proposed Changes
Fixed one word choice error in the sentence, "CategoryEncoders internally works with pandas DataFrames as apposed to sklearn, which works with numpy arrays." The phrase "as apposed to" should be "as opposed to."