### PR TITLE
encoders: validate handle_missing/handle_unknown strings (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+unreleased
+==========
+
+* Fix: Fixed issue#168 - encoders now raise ValueError on unrecognised
+  handle_missing/handle_unknown string values instead of silently treating
+  them as the default.
+
 v.2.9.0
 =======
 

--- a/category_encoders/base_contrast_encoder.py
+++ b/category_encoders/base_contrast_encoder.py
@@ -48,6 +48,13 @@ class BaseContrastEncoder(util.UnsupervisedTransformerMixin, util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.ONE_TO_N_UNIQUE
+    # Contrast-coding encoders (Polynomial, Sum, Helmert, BackwardDifference)
+    # accept 'indicator' for both handle_missing and handle_unknown — see
+    # tests/test_polynomial.py::test_handle_missing_is_indicator. Without the
+    # extra entry the new validation in BaseEncoder.fit (issue #168) would
+    # reject these documented strategies.
+    _VALID_HANDLE_MISSING = ('error', 'return_nan', 'value', 'indicator')
+    _VALID_HANDLE_UNKNOWN = ('error', 'return_nan', 'value', 'indicator')
 
     def __init__(
         self,

--- a/category_encoders/base_contrast_encoder.py
+++ b/category_encoders/base_contrast_encoder.py
@@ -48,11 +48,6 @@ class BaseContrastEncoder(util.UnsupervisedTransformerMixin, util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.ONE_TO_N_UNIQUE
-    # Contrast-coding encoders (Polynomial, Sum, Helmert, BackwardDifference)
-    # accept 'indicator' for both handle_missing and handle_unknown — see
-    # tests/test_polynomial.py::test_handle_missing_is_indicator. Without the
-    # extra entry the new validation in BaseEncoder.fit (issue #168) would
-    # reject these documented strategies.
     _VALID_HANDLE_MISSING = ('error', 'return_nan', 'value', 'indicator')
     _VALID_HANDLE_UNKNOWN = ('error', 'return_nan', 'value', 'indicator')
 

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -107,10 +107,6 @@ class BaseNEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.N_TO_M
-    # BaseN/Binary/Gray accept 'indicator' for both handle_missing and
-    # handle_unknown (extra column flagging missing/unseen categories) — see
-    # tests/test_basen.py::test_handle_missing_indicator_with_nan and
-    # tests/test_one_hot.py::test_handle_unknown_indicator. Issue #168.
     _VALID_HANDLE_MISSING = ('error', 'return_nan', 'value', 'indicator')
     _VALID_HANDLE_UNKNOWN = ('error', 'return_nan', 'value', 'indicator')
 

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -107,6 +107,12 @@ class BaseNEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.N_TO_M
+    # BaseN/Binary/Gray accept 'indicator' for both handle_missing and
+    # handle_unknown (extra column flagging missing/unseen categories) — see
+    # tests/test_basen.py::test_handle_missing_indicator_with_nan and
+    # tests/test_one_hot.py::test_handle_unknown_indicator. Issue #168.
+    _VALID_HANDLE_MISSING = ('error', 'return_nan', 'value', 'indicator')
+    _VALID_HANDLE_UNKNOWN = ('error', 'return_nan', 'value', 'indicator')
 
     def __init__(
         self,

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -19,6 +19,12 @@ class CountEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.ONE_TO_ONE
+    # CountEncoder accepts ints and dicts (per-column options) for
+    # handle_unknown / handle_missing, so a flat string-set check is too
+    # restrictive — opt out and rely on the encoder's own normalisation
+    # logic. See issue #168.
+    _VALID_HANDLE_MISSING = None
+    _VALID_HANDLE_UNKNOWN = None
 
     def __init__(
         self,

--- a/category_encoders/count.py
+++ b/category_encoders/count.py
@@ -19,10 +19,6 @@ class CountEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.ONE_TO_ONE
-    # CountEncoder accepts ints and dicts (per-column options) for
-    # handle_unknown / handle_missing, so a flat string-set check is too
-    # restrictive — opt out and rely on the encoder's own normalisation
-    # logic. See issue #168.
     _VALID_HANDLE_MISSING = None
     _VALID_HANDLE_UNKNOWN = None
 

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -119,6 +119,12 @@ class HashingEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = False
     encoding_relation = util.EncodingRelation.ONE_TO_M
+    # HashingEncoder uses a sentinel 'does not apply' value because the hash
+    # makes handle_missing/handle_unknown semantically irrelevant. Opt out of
+    # the BaseEncoder string-set validation to keep that sentinel valid. See
+    # issue #168.
+    _VALID_HANDLE_MISSING = None
+    _VALID_HANDLE_UNKNOWN = None
 
     def __init__(
         self,

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -119,10 +119,6 @@ class HashingEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = False
     encoding_relation = util.EncodingRelation.ONE_TO_M
-    # HashingEncoder uses a sentinel 'does not apply' value because the hash
-    # makes handle_missing/handle_unknown semantically irrelevant. Opt out of
-    # the BaseEncoder string-set validation to keep that sentinel valid. See
-    # issue #168.
     _VALID_HANDLE_MISSING = None
     _VALID_HANDLE_UNKNOWN = None
 

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -106,8 +106,6 @@ class OneHotEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.ONE_TO_N_UNIQUE
-    # OneHotEncoder additionally accepts 'ignore' and 'indicator' beyond the
-    # base BaseEncoder defaults. See issue #168.
     _VALID_HANDLE_MISSING = ('error', 'return_nan', 'value', 'ignore', 'indicator')
     _VALID_HANDLE_UNKNOWN = ('error', 'return_nan', 'value', 'indicator')
 

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -106,6 +106,10 @@ class OneHotEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
     prefit_ordinal = True
     encoding_relation = util.EncodingRelation.ONE_TO_N_UNIQUE
+    # OneHotEncoder additionally accepts 'ignore' and 'indicator' beyond the
+    # base BaseEncoder defaults. See issue #168.
+    _VALID_HANDLE_MISSING = ('error', 'return_nan', 'value', 'ignore', 'indicator')
+    _VALID_HANDLE_UNKNOWN = ('error', 'return_nan', 'value', 'indicator')
 
     def __init__(
         self,

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -387,6 +387,16 @@ class BaseEncoder(BaseEstimator):
         # scale-independent and handles normalized/proportion values correctly.
     )
 
+    # Allowed string values for the ``handle_missing`` and ``handle_unknown``
+    # arguments. Subclasses that accept additional values (e.g. OneHotEncoder
+    # also supports 'ignore' and 'indicator' for ``handle_missing``) override
+    # these tuples. A value of ``None`` disables validation, which is used by
+    # encoders like CountEncoder/HashingEncoder that accept richer types
+    # (dicts, ints, sentinel strings) where a flat string-set check is wrong.
+    # See issue #168.
+    _VALID_HANDLE_MISSING: tuple[str, ...] | None = ('error', 'return_nan', 'value')
+    _VALID_HANDLE_UNKNOWN: tuple[str, ...] | None = ('error', 'return_nan', 'value')
+
     def __init__(
         self,
         verbose: int = 0,
@@ -456,6 +466,11 @@ class BaseEncoder(BaseEstimator):
         """
         X, y = convert_inputs(X, y)
         self._check_fit_inputs(X, y)
+        # Validate that handle_missing/handle_unknown are values this encoder
+        # actually understands. Done here (rather than __init__) to follow the
+        # sklearn convention of deferring parameter validation to fit, so that
+        # ``clone()`` and ``set_params`` keep working. See issue #168.
+        self._validate_handle_strategies()
         self.feature_names_in_ = X.columns.tolist()
         self.n_features_in_ = len(self.feature_names_in_)
 
@@ -505,6 +520,34 @@ class BaseEncoder(BaseEstimator):
             else:
                 if y.isna().any():  # Target column should never have missing values
                     raise ValueError('The target column y must not contain missing values.')
+
+    def _validate_handle_strategies(self) -> None:
+        """Validate that handle_missing/handle_unknown are recognised string values.
+
+        Encoders silently ignored unrecognised string options before this check
+        existed, so a typo like ``handle_missing='retunr_nan'`` would be treated
+        the same as the default ``'value'`` with no warning. This now raises a
+        clear ``ValueError`` listing the supported values for the encoder. See
+        issue #168.
+
+        Subclasses that legitimately accept richer types (CountEncoder and
+        HashingEncoder accept dicts/ints/sentinel strings) set the matching
+        class attribute to ``None`` to opt out of validation.
+        """
+        valid_missing = type(self)._VALID_HANDLE_MISSING
+        if valid_missing is not None and isinstance(self.handle_missing, str):
+            if self.handle_missing not in valid_missing:
+                raise ValueError(
+                    f'Unexpected handle_missing value {self.handle_missing!r} for '
+                    f'{type(self).__name__}. Supported values: {sorted(valid_missing)}.'
+                )
+        valid_unknown = type(self)._VALID_HANDLE_UNKNOWN
+        if valid_unknown is not None and isinstance(self.handle_unknown, str):
+            if self.handle_unknown not in valid_unknown:
+                raise ValueError(
+                    f'Unexpected handle_unknown value {self.handle_unknown!r} for '
+                    f'{type(self).__name__}. Supported values: {sorted(valid_unknown)}.'
+                )
 
     def _check_transform_inputs(self, df: pd.DataFrame) -> None:
         if self.handle_missing == 'error':

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -387,13 +387,9 @@ class BaseEncoder(BaseEstimator):
         # scale-independent and handles normalized/proportion values correctly.
     )
 
-    # Allowed string values for the ``handle_missing`` and ``handle_unknown``
-    # arguments. Subclasses that accept additional values (e.g. OneHotEncoder
-    # also supports 'ignore' and 'indicator' for ``handle_missing``) override
-    # these tuples. A value of ``None`` disables validation, which is used by
-    # encoders like CountEncoder/HashingEncoder that accept richer types
-    # (dicts, ints, sentinel strings) where a flat string-set check is wrong.
-    # See issue #168.
+    # Subclasses may override with a wider tuple, or set to None to opt out of
+    # string validation (CountEncoder accepts dicts/ints; HashingEncoder uses a
+    # sentinel string).
     _VALID_HANDLE_MISSING: tuple[str, ...] | None = ('error', 'return_nan', 'value')
     _VALID_HANDLE_UNKNOWN: tuple[str, ...] | None = ('error', 'return_nan', 'value')
 
@@ -466,10 +462,6 @@ class BaseEncoder(BaseEstimator):
         """
         X, y = convert_inputs(X, y)
         self._check_fit_inputs(X, y)
-        # Validate that handle_missing/handle_unknown are values this encoder
-        # actually understands. Done here (rather than __init__) to follow the
-        # sklearn convention of deferring parameter validation to fit, so that
-        # ``clone()`` and ``set_params`` keep working. See issue #168.
         self._validate_handle_strategies()
         self.feature_names_in_ = X.columns.tolist()
         self.n_features_in_ = len(self.feature_names_in_)
@@ -522,18 +514,7 @@ class BaseEncoder(BaseEstimator):
                     raise ValueError('The target column y must not contain missing values.')
 
     def _validate_handle_strategies(self) -> None:
-        """Validate that handle_missing/handle_unknown are recognised string values.
-
-        Encoders silently ignored unrecognised string options before this check
-        existed, so a typo like ``handle_missing='retunr_nan'`` would be treated
-        the same as the default ``'value'`` with no warning. This now raises a
-        clear ``ValueError`` listing the supported values for the encoder. See
-        issue #168.
-
-        Subclasses that legitimately accept richer types (CountEncoder and
-        HashingEncoder accept dicts/ints/sentinel strings) set the matching
-        class attribute to ``None`` to opt out of validation.
-        """
+        """Raise ValueError if handle_missing/handle_unknown are unrecognised strings."""
         valid_missing = type(self)._VALID_HANDLE_MISSING
         if valid_missing is not None and isinstance(self.handle_missing, str):
             if self.handle_missing not in valid_missing:

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1002,3 +1002,53 @@ class TestEncoders(TestCase):
                 enc = getattr(encoders, encoder_name)(cols=['col1'])
                 out = enc.fit_transform(X, y)
                 self.assertTrue(out.col2[2] is None)
+
+    def test_invalid_handle_missing_raises(self):
+        """Encoders should raise ValueError on unrecognised handle_missing strings.
+
+        Before issue #168 was fixed, an unsupported value (e.g. 'indicator' on
+        TargetEncoder, which only understands 'error'/'return_nan'/'value')
+        was silently accepted and the encoder behaved as if the default were
+        passed, which made typos very easy to miss. The base encoder now
+        validates against the encoder-specific allow-list at fit time.
+        """
+        # Encoders that opt out of validation by setting _VALID_HANDLE_* = None
+        # (CountEncoder accepts dicts/ints; HashingEncoder uses sentinel
+        # 'does not apply'). They are exercised separately by other tests.
+        opted_out = {'CountEncoder', 'HashingEncoder'}
+        bad_value = 'definitely_not_a_handle_missing_value'
+
+        for encoder_name in set(encoders.__all__) - opted_out:
+            with self.subTest(encoder_name=encoder_name):
+                enc = getattr(encoders, encoder_name)(handle_missing=bad_value)
+                with self.assertRaisesRegex(ValueError, r'handle_missing'):
+                    enc.fit(X, np_y)
+
+    def test_invalid_handle_unknown_raises(self):
+        """Encoders should raise ValueError on unrecognised handle_unknown strings.
+
+        See issue #168.
+        """
+        opted_out = {'CountEncoder', 'HashingEncoder'}
+        bad_value = 'definitely_not_a_handle_unknown_value'
+
+        for encoder_name in set(encoders.__all__) - opted_out:
+            with self.subTest(encoder_name=encoder_name):
+                enc = getattr(encoders, encoder_name)(handle_unknown=bad_value)
+                with self.assertRaisesRegex(ValueError, r'handle_unknown'):
+                    enc.fit(X, np_y)
+
+    def test_one_hot_extra_handle_strategies_still_accepted(self):
+        """OneHotEncoder accepts 'ignore' and 'indicator' on top of the base set.
+
+        Regression guard: the per-encoder _VALID_HANDLE_* override on
+        OneHotEncoder must not regress to the base set. See issue #168.
+        """
+        for missing_strat in ('ignore', 'indicator'):
+            with self.subTest(handle_missing=missing_strat):
+                enc = encoders.OneHotEncoder(handle_missing=missing_strat)
+                enc.fit(X)  # must not raise
+        for unknown_strat in ('indicator',):
+            with self.subTest(handle_unknown=unknown_strat):
+                enc = encoders.OneHotEncoder(handle_unknown=unknown_strat)
+                enc.fit(X)  # must not raise

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1004,51 +1004,24 @@ class TestEncoders(TestCase):
                 self.assertTrue(out.col2[2] is None)
 
     def test_invalid_handle_missing_raises(self):
-        """Encoders should raise ValueError on unrecognised handle_missing strings.
-
-        Before issue #168 was fixed, an unsupported value (e.g. 'indicator' on
-        TargetEncoder, which only understands 'error'/'return_nan'/'value')
-        was silently accepted and the encoder behaved as if the default were
-        passed, which made typos very easy to miss. The base encoder now
-        validates against the encoder-specific allow-list at fit time.
-        """
-        # Encoders that opt out of validation by setting _VALID_HANDLE_* = None
-        # (CountEncoder accepts dicts/ints; HashingEncoder uses sentinel
-        # 'does not apply'). They are exercised separately by other tests.
         opted_out = {'CountEncoder', 'HashingEncoder'}
-        bad_value = 'definitely_not_a_handle_missing_value'
-
         for encoder_name in set(encoders.__all__) - opted_out:
             with self.subTest(encoder_name=encoder_name):
-                enc = getattr(encoders, encoder_name)(handle_missing=bad_value)
+                enc = getattr(encoders, encoder_name)(handle_missing='not_a_real_value')
                 with self.assertRaisesRegex(ValueError, r'handle_missing'):
                     enc.fit(X, np_y)
 
     def test_invalid_handle_unknown_raises(self):
-        """Encoders should raise ValueError on unrecognised handle_unknown strings.
-
-        See issue #168.
-        """
         opted_out = {'CountEncoder', 'HashingEncoder'}
-        bad_value = 'definitely_not_a_handle_unknown_value'
-
         for encoder_name in set(encoders.__all__) - opted_out:
             with self.subTest(encoder_name=encoder_name):
-                enc = getattr(encoders, encoder_name)(handle_unknown=bad_value)
+                enc = getattr(encoders, encoder_name)(handle_unknown='not_a_real_value')
                 with self.assertRaisesRegex(ValueError, r'handle_unknown'):
                     enc.fit(X, np_y)
 
     def test_one_hot_extra_handle_strategies_still_accepted(self):
-        """OneHotEncoder accepts 'ignore' and 'indicator' on top of the base set.
-
-        Regression guard: the per-encoder _VALID_HANDLE_* override on
-        OneHotEncoder must not regress to the base set. See issue #168.
-        """
-        for missing_strat in ('ignore', 'indicator'):
-            with self.subTest(handle_missing=missing_strat):
-                enc = encoders.OneHotEncoder(handle_missing=missing_strat)
-                enc.fit(X)  # must not raise
-        for unknown_strat in ('indicator',):
-            with self.subTest(handle_unknown=unknown_strat):
-                enc = encoders.OneHotEncoder(handle_unknown=unknown_strat)
-                enc.fit(X)  # must not raise
+        for strat in ('ignore', 'indicator'):
+            with self.subTest(handle_missing=strat):
+                encoders.OneHotEncoder(handle_missing=strat).fit(X)
+        with self.subTest(handle_unknown='indicator'):
+            encoders.OneHotEncoder(handle_unknown='indicator').fit(X)

--- a/tests/test_ordinal.py
+++ b/tests/test_ordinal.py
@@ -388,10 +388,6 @@ class TestOrdinalEncoder(TestCase):
         for msg, mapping in mappings.items():
             with self.subTest(msg):
                 df = X.copy(deep=True)
-                # OrdinalEncoder accepts {'error', 'return_nan', 'value'};
-                # 'ignore' was previously silently treated as 'value' but is
-                # not a documented option. Pass the supported value
-                # explicitly. See issue #168.
                 enc = encoders.OrdinalEncoder(
                     cols=categoricals,
                     handle_unknown='value',

--- a/tests/test_ordinal.py
+++ b/tests/test_ordinal.py
@@ -388,9 +388,13 @@ class TestOrdinalEncoder(TestCase):
         for msg, mapping in mappings.items():
             with self.subTest(msg):
                 df = X.copy(deep=True)
+                # OrdinalEncoder accepts {'error', 'return_nan', 'value'};
+                # 'ignore' was previously silently treated as 'value' but is
+                # not a documented option. Pass the supported value
+                # explicitly. See issue #168.
                 enc = encoders.OrdinalEncoder(
                     cols=categoricals,
-                    handle_unknown='ignore',
+                    handle_unknown='value',
                     mapping=mapping,
                     return_df=True,
                 )


### PR DESCRIPTION
Fixes #168

## Proposed Changes

- Add a `_validate_handle_strategies` hook on `BaseEncoder` that runs at
  fit time and rejects unrecognised `handle_missing` / `handle_unknown`
  string values with a clear `ValueError` listing the supported options.
- Default the allow-list on `BaseEncoder` to `('error', 'return_nan',
  'value')` and override per encoder where the documented option set is
  larger:
  - `OneHotEncoder` — additionally `'ignore'` and `'indicator'` for
    `handle_missing`, `'indicator'` for `handle_unknown`.
  - `BaseNEncoder` (and `BinaryEncoder` / `GrayEncoder`) — `'indicator'`
    for both.
  - `BaseContrastEncoder` (`PolynomialEncoder`, `SumEncoder`,
    `HelmertEncoder`, `BackwardDifferenceEncoder`) — `'indicator'` for
    both.
- `CountEncoder` and `HashingEncoder` opt out by setting the class
  attributes to `None`. `CountEncoder` legitimately accepts ints and
  per-column `dict` mappings, and `HashingEncoder` uses the sentinel
  string `'does not apply'`. A flat string-set check would be wrong for
  both.
- One existing test (`tests/test_ordinal.py::test_inverse_with_mapping`)
  was passing `handle_unknown='ignore'` to `OrdinalEncoder`, which is
  *not* a documented option and was being silently treated as `'value'`
  — exactly the bug this PR fixes. The test now passes the supported
  `'value'` explicitly with an inline comment explaining the rename.

## Why

Before this change, a typo like `TargetEncoder(handle_missing='retunr_nan')`
or a misuse like `OrdinalEncoder(handle_unknown='ignore')` was silently
accepted and the encoder defaulted to `'value'` semantics. The reporter
flagged this back in 2019 and even shipped the suggested validation
snippet in the issue body.

The validation runs in `fit` (not `__init__`) to follow the sklearn
convention so that `clone()` and `set_params` keep working.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/scikit-learn-contrib/category_encoders.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e .

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "
from category_encoders import TargetEncoder
import pandas as pd
te = TargetEncoder(handle_missing='indicator')  # not a TargetEncoder option
data = pd.DataFrame({'c1': ['a', 'b', 'a']})
y = pd.Series([1, 0, 1])
print(te.fit_transform(data, y))  # silently 'works'
"
# Expected: prints an encoded dataframe; the typo is silently ignored.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/category_encoders.git feat/168-validate-handle-missing-args
git checkout FETCH_HEAD
pip install -e .
python -c "
from category_encoders import TargetEncoder
import pandas as pd
te = TargetEncoder(handle_missing='indicator')
data = pd.DataFrame({'c1': ['a', 'b', 'a']})
y = pd.Series([1, 0, 1])
te.fit_transform(data, y)
"
# Expected: ValueError: Unexpected handle_missing value 'indicator' for TargetEncoder.
#           Supported values: ['error', 'return_nan', 'value'].
```

## What I ran locally

- `pytest tests/` on this branch → 215 passed, 24 pre-existing failures
  (verified identical set on `origin/master` — pandas 3 / numpy 2 compat
  issues unrelated to this change).
- `pytest tests/test_encoders.py::TestEncoders::test_invalid_handle_missing_raises tests/test_encoders.py::TestEncoders::test_invalid_handle_unknown_raises tests/test_encoders.py::TestEncoders::test_one_hot_extra_handle_strategies_still_accepted -v`
  → 3 passed, 41 subtests passed.
- `pytest tests/test_basen.py tests/test_polynomial.py tests/test_sum_coding.py tests/test_helmert.py tests/test_backward_difference.py tests/test_ordinal.py tests/test_one_hot.py tests/test_binary.py tests/test_gray.py`
  → 69 passed, 35 subtests passed (all encoder-specific suites that exercise
  the documented `handle_*` options).
- `ruff check category_encoders/utils.py category_encoders/one_hot.py category_encoders/basen.py category_encoders/count.py category_encoders/hashing.py category_encoders/base_contrast_encoder.py` → All checks passed.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Typo on `handle_missing` for an encoder using the base set | `TargetEncoder(handle_missing='retunr_nan')` | `ValueError` listing `['error', 'return_nan', 'value']` | `test_invalid_handle_missing_raises` (loops over all encoders) |
| 2 | Typo on `handle_unknown` for an encoder using the base set | `OrdinalEncoder(handle_unknown='something')` | `ValueError` listing `['error', 'return_nan', 'value']` | `test_invalid_handle_unknown_raises` |
| 3 | Documented extension on `OneHotEncoder` | `OneHotEncoder(handle_missing='ignore')`, `OneHotEncoder(handle_missing='indicator')`, `OneHotEncoder(handle_unknown='indicator')` | succeeds, behaves as before | `test_one_hot_extra_handle_strategies_still_accepted` |
| 4 | Documented extension on `BaseNEncoder` | `BaseNEncoder(handle_missing='indicator')` | succeeds | existing `test_handle_missing_indicator_with_nan` |
| 5 | Documented extension on contrast encoders | `PolynomialEncoder(handle_missing='indicator')` | succeeds | existing `test_handle_missing_is_indicator` |
| 6 | Opt-out — `CountEncoder` accepts dicts/ints | `CountEncoder(handle_missing={'col': 'value'})` | succeeds (no validation) | full `tests/test_count.py` suite still green |
| 7 | Opt-out — `HashingEncoder` uses sentinel `'does not apply'` | default construction | succeeds | full `tests/test_hashing.py` still green |

## Risk / blast radius

Behaviorally additive: code paths that already passed a documented option
keep working. Code paths that passed an undocumented string that *happened*
to fall through to the default now raise. The one such code path I found
in the test suite (`test_inverse_with_mapping` passing
`handle_unknown='ignore'` to `OrdinalEncoder`) is updated in this PR.

I did **not** add new exceptions for non-string values (CountEncoder
ints/dicts, HashingEncoder sentinel) — those encoders opt out of the
validation entirely via `_VALID_HANDLE_* = None`, preserving their
existing flexibility.

## Release note

```release-note
Fix: encoders now raise ValueError on unrecognised handle_missing /
handle_unknown string values instead of silently treating them as the
default.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against scikit-learn-contrib/category_encoders source and the
issue's reproducer was used during development; it is the same one a
reviewer can paste verbatim.*
