### PR TITLE
encoders: honor return_df=False when cols list is empty (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+* Fix: Fixed issue#442 - encoders now honor return_df=False even when
+  the resolved column list is empty (e.g. on a numeric-only DataFrame).
+
 v.2.9.0
 =======
 

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -631,7 +631,11 @@ class SupervisedTransformerMixin(sklearn.base.TransformerMixin):
             y = pd.Series(self.lab_encoder_.transform(y), index=y.index)
 
         if not list(self.cols):
-            return X
+            # No columns to encode: still honor return_df so callers that
+            # pass return_df=False to a frame containing only numeric inputs
+            # get back a numpy array consistently with the non-empty-cols
+            # path. See issue #442.
+            return X if (self.return_df or override_return_df) else X.to_numpy()
 
         X = self._transform(X, y)
 
@@ -673,7 +677,9 @@ class UnsupervisedTransformerMixin(sklearn.base.TransformerMixin):
         self._check_transform_inputs(X)
 
         if not list(self.cols):
-            return X
+            # See SupervisedTransformerMixin.transform — same return_df fix
+            # for the unsupervised path. Issue #442.
+            return X if (self.return_df or override_return_df) else X.to_numpy()
 
         X = self._transform(X)
         return self._drop_invariants(X, override_return_df)

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -631,10 +631,6 @@ class SupervisedTransformerMixin(sklearn.base.TransformerMixin):
             y = pd.Series(self.lab_encoder_.transform(y), index=y.index)
 
         if not list(self.cols):
-            # No columns to encode: still honor return_df so callers that
-            # pass return_df=False to a frame containing only numeric inputs
-            # get back a numpy array consistently with the non-empty-cols
-            # path. See issue #442.
             return X if (self.return_df or override_return_df) else X.to_numpy()
 
         X = self._transform(X, y)
@@ -677,8 +673,6 @@ class UnsupervisedTransformerMixin(sklearn.base.TransformerMixin):
         self._check_transform_inputs(X)
 
         if not list(self.cols):
-            # See SupervisedTransformerMixin.transform — same return_df fix
-            # for the unsupervised path. Issue #442.
             return X if (self.return_df or override_return_df) else X.to_numpy()
 
         X = self._transform(X)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1004,30 +1004,14 @@ class TestEncoders(TestCase):
                 self.assertTrue(out.col2[2] is None)
 
     def test_return_df_false_honored_when_no_categorical_cols(self):
-        """``return_df=False`` produces ndarray even when there are no
-        categorical columns to encode.
-
-        Regression for issue #442. The encoder previously returned the
-        original DataFrame on the no-op path, ignoring ``return_df``.
-        """
         rng = np.random.RandomState(42)
         df = pd.DataFrame(rng.normal(size=(50, 3)), columns=['a', 'b', 'c'])
         empty_cols = df.select_dtypes(include=['object', 'bool']).columns
-
-        # HashingEncoder ignores ``cols`` entirely (it hashes everything),
-        # CountEncoder fails on numeric-only inputs under its default
-        # missing strategy. Both are exercised by their own suites.
         skip = {'HashingEncoder', 'CountEncoder'}
-
         for encoder_name in set(encoders.__all__) - skip:
             with self.subTest(encoder_name=encoder_name):
                 enc = getattr(encoders, encoder_name)(
                     cols=empty_cols, return_df=False, handle_missing='return_nan'
                 )
                 out = enc.fit_transform(df, np_y[:50])
-                self.assertIsInstance(
-                    out,
-                    np.ndarray,
-                    f'{encoder_name}: expected ndarray when return_df=False '
-                    f'and cols is empty, got {type(out).__name__}',
-                )
+                self.assertIsInstance(out, np.ndarray)

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1002,3 +1002,32 @@ class TestEncoders(TestCase):
                 enc = getattr(encoders, encoder_name)(cols=['col1'])
                 out = enc.fit_transform(X, y)
                 self.assertTrue(out.col2[2] is None)
+
+    def test_return_df_false_honored_when_no_categorical_cols(self):
+        """``return_df=False`` produces ndarray even when there are no
+        categorical columns to encode.
+
+        Regression for issue #442. The encoder previously returned the
+        original DataFrame on the no-op path, ignoring ``return_df``.
+        """
+        rng = np.random.RandomState(42)
+        df = pd.DataFrame(rng.normal(size=(50, 3)), columns=['a', 'b', 'c'])
+        empty_cols = df.select_dtypes(include=['object', 'bool']).columns
+
+        # HashingEncoder ignores ``cols`` entirely (it hashes everything),
+        # CountEncoder fails on numeric-only inputs under its default
+        # missing strategy. Both are exercised by their own suites.
+        skip = {'HashingEncoder', 'CountEncoder'}
+
+        for encoder_name in set(encoders.__all__) - skip:
+            with self.subTest(encoder_name=encoder_name):
+                enc = getattr(encoders, encoder_name)(
+                    cols=empty_cols, return_df=False, handle_missing='return_nan'
+                )
+                out = enc.fit_transform(df, np_y[:50])
+                self.assertIsInstance(
+                    out,
+                    np.ndarray,
+                    f'{encoder_name}: expected ndarray when return_df=False '
+                    f'and cols is empty, got {type(out).__name__}',
+                )


### PR DESCRIPTION
Fixes #442

## Proposed Changes

- In `SupervisedTransformerMixin.transform` and
  `UnsupervisedTransformerMixin.transform` (`category_encoders/utils.py`),
  honor `return_df` on the early-return path that handles "no columns to
  encode" — return `X.to_numpy()` when `return_df=False` (and
  `override_return_df` is also false), otherwise return the DataFrame.
- Add `tests/test_encoders.py::test_return_df_false_honored_when_no_categorical_cols`
  that loops over every encoder (skipping `HashingEncoder`, which hashes
  every column regardless of `cols`, and `CountEncoder`, which fails on
  numeric-only inputs under its default missing strategy) and asserts the
  output is `np.ndarray`.

## Why

A user calling
```python
encoder = OneHotEncoder(
    cols=df.select_dtypes(include=['object', 'bool']).columns,
    return_df=False,
)
encoder.fit_transform(df)
```
on a numeric-only DataFrame got a DataFrame back. The early-return path
short-circuited before `return_df` was applied, breaking the
`return_df=False` contract.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/scikit-learn-contrib/category_encoders.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e .

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "
import numpy as np, pandas as pd
from category_encoders.one_hot import OneHotEncoder
rng = np.random.RandomState(42)
df = pd.DataFrame(rng.normal(size=(200, 2)), columns=['a', 'b'])
enc = OneHotEncoder(cols=df.select_dtypes(include=['object', 'bool']).columns, return_df=False, handle_missing='return_nan')
print(type(enc.fit_transform(df)).__name__)
"
# Expected: DataFrame  (bug — return_df=False is ignored)

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/category_encoders.git feat/442-honor-return-df-when-cols-empty
git checkout FETCH_HEAD
pip install -e .
python -c "
import numpy as np, pandas as pd
from category_encoders.one_hot import OneHotEncoder
rng = np.random.RandomState(42)
df = pd.DataFrame(rng.normal(size=(200, 2)), columns=['a', 'b'])
enc = OneHotEncoder(cols=df.select_dtypes(include=['object', 'bool']).columns, return_df=False, handle_missing='return_nan')
print(type(enc.fit_transform(df)).__name__)
"
# Expected: ndarray
```

## What I ran locally

- New regression test
  `tests/test_encoders.py::TestEncoders::test_return_df_false_honored_when_no_categorical_cols`:
  - On `origin/master`: 18 / 19 subtests fail (every supervised encoder + most
    unsupervised ones return DataFrame instead of ndarray).
  - On this branch: 19 / 19 subtests pass.
- Full `pytest tests/`: 213 passed, 24 pre-existing failures (verified
  identical set on `origin/master` — pandas 3 / numpy 2 compat issues
  unrelated to this change), 2 skipped.
- `ruff check category_encoders/utils.py` → All checks passed.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | `cols=[]` resolved from `select_dtypes` on numeric-only DF, `return_df=False` | numeric-only DataFrame | `np.ndarray` | new test, all encoders except `HashingEncoder`/`CountEncoder` |
| 2 | `cols=[]`, `return_df=True` (default) | same | DataFrame | existing tests (no behavior change on this path) |
| 3 | Non-empty `cols`, `return_df=False` | DataFrame with categorical column | `np.ndarray` | existing `_drop_invariants` path, unchanged |

## Risk / blast radius

Behaviorally additive: only the no-op early-return branch is touched. The
non-empty-cols path already used `_drop_invariants(..., override_return_df)`,
which honors `return_df`. After this PR both paths are consistent.

The maintainer's [comment on the issue](https://github.com/scikit-learn-contrib/category_encoders/issues/442#issuecomment-2386982492)
also mentions accepting pandas `Index` for `cols`. This PR keeps that
half open as a follow-up — the user's example already works (the
DataFrame-vs-ndarray issue is independent of how `cols` was constructed).

## Release note

```release-note
Fix: encoders now honor return_df=False even when the resolved column
list is empty (e.g. on a numeric-only DataFrame).
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against scikit-learn-contrib/category_encoders source and the
issue's reproducer was used during development; it is the same one a
reviewer can paste verbatim.*
