### PR TITLE
basen, one_hot: clear inverse_transform error with drop_invariant (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+unreleased
+==========
+
+* Fix: Fixed issue#190 - inverse_transform with drop_invariant=True now
+  raises a clear ValueError instead of an opaque IndexError /
+  "X is not in list" error.
+
 v.2.9.0
 =======
 

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -213,17 +213,24 @@ class BaseNEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         # and make a deep copy
         X = util.convert_input(X_in, columns=self.feature_names_out_, deep=True)
 
+        # Validate the input dimension *before* basen_to_integer, which
+        # otherwise would raise an opaque IndexError when drop_invariant
+        # has stripped some encoded columns: basen_to_integer iterates the
+        # full set of encoded digits per column, but the input no longer
+        # provides them. Refuse with a clear ValueError pointing at
+        # drop_invariant. See issue #190.
+        if self.drop_invariant and self.invariant_cols:
+            raise ValueError(
+                f'Unexpected input dimension {X.shape[1]}, the attribute drop_invariant '
+                'should be False when calling inverse_transform'
+            )
+
         X = self.basen_to_integer(X, self.cols, self.base)
 
-        # make sure that it is the right size
+        # Catch any remaining dim mismatch (e.g. caller passed an unrelated
+        # frame with the right column names but extra columns).
         if X.shape[1] != self._dim:
-            if self.drop_invariant:
-                raise ValueError(
-                    f'Unexpected input dimension {X.shape[1]}, the attribute drop_invariant should '
-                    'be False when transforming the data'
-                )
-            else:
-                raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
+            raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 
         if not list(self.cols):
             return X if self.return_df else X.to_numpy()

--- a/category_encoders/basen.py
+++ b/category_encoders/basen.py
@@ -213,12 +213,6 @@ class BaseNEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         # and make a deep copy
         X = util.convert_input(X_in, columns=self.feature_names_out_, deep=True)
 
-        # Validate the input dimension *before* basen_to_integer, which
-        # otherwise would raise an opaque IndexError when drop_invariant
-        # has stripped some encoded columns: basen_to_integer iterates the
-        # full set of encoded digits per column, but the input no longer
-        # provides them. Refuse with a clear ValueError pointing at
-        # drop_invariant. See issue #190.
         if self.drop_invariant and self.invariant_cols:
             raise ValueError(
                 f'Unexpected input dimension {X.shape[1]}, the attribute drop_invariant '
@@ -227,8 +221,6 @@ class BaseNEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
         X = self.basen_to_integer(X, self.cols, self.base)
 
-        # Catch any remaining dim mismatch (e.g. caller passed an unrelated
-        # frame with the right column names but extra columns).
         if X.shape[1] != self._dim:
             raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -252,17 +252,22 @@ class OneHotEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         # first check the type and make deep copy
         X = util.convert_input(X_in, columns=self.feature_names_out_, deep=True)
 
+        # Refuse early when drop_invariant stripped encoded columns:
+        # reverse_dummies iterates ``self.mapping`` which still references
+        # the dropped columns, so the user would otherwise see an opaque
+        # ``ValueError: '<col>_<level>' is not in list``. See issue #190.
+        if self.drop_invariant and self.invariant_cols:
+            raise ValueError(
+                f'Unexpected input dimension {X.shape[1]}, the attribute drop_invariant '
+                'should be False when calling inverse_transform'
+            )
+
         X = self.reverse_dummies(X, self.mapping)
 
-        # then make sure that it is the right size
+        # Catch any remaining dim mismatch (e.g. caller passed an unrelated
+        # frame with the right column names but extra columns).
         if X.shape[1] != self._dim:
-            if self.drop_invariant:
-                raise ValueError(
-                    f'Unexpected input dimension {X.shape[1]}, the attribute drop_invariant should '
-                    'be False when transforming the data'
-                )
-            else:
-                raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
+            raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 
         if not list(self.cols):
             return X if self.return_df else X.to_numpy()

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -252,10 +252,6 @@ class OneHotEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         # first check the type and make deep copy
         X = util.convert_input(X_in, columns=self.feature_names_out_, deep=True)
 
-        # Refuse early when drop_invariant stripped encoded columns:
-        # reverse_dummies iterates ``self.mapping`` which still references
-        # the dropped columns, so the user would otherwise see an opaque
-        # ``ValueError: '<col>_<level>' is not in list``. See issue #190.
         if self.drop_invariant and self.invariant_cols:
             raise ValueError(
                 f'Unexpected input dimension {X.shape[1]}, the attribute drop_invariant '
@@ -264,8 +260,6 @@ class OneHotEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
 
         X = self.reverse_dummies(X, self.mapping)
 
-        # Catch any remaining dim mismatch (e.g. caller passed an unrelated
-        # frame with the right column names but extra columns).
         if X.shape[1] != self._dim:
             raise ValueError(f'Unexpected input dimension {X.shape[1]}, expected {self._dim}')
 

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1004,24 +1004,10 @@ class TestEncoders(TestCase):
                 self.assertTrue(out.col2[2] is None)
 
     def test_inverse_transform_with_drop_invariant_raises_clean_error(self):
-        """inverse_transform with drop_invariant=True must raise a clear
-        ValueError, not an opaque IndexError or KeyError.
-
-        The encoders cannot reconstruct the input when invariant columns
-        have been dropped — that information is no longer available — so
-        refusing the call is correct. Issue #190 sets the bar that the
-        message starts with 'Unexpected input dimension' for every
-        encoder that supports drop_invariant.
-        """
-        x = [['A', 'B', 'C'], ['D', 'E', 'C'], ['F', 'G', 'C']]  # last col invariant
+        x = [['A', 'B', 'C'], ['D', 'E', 'C'], ['F', 'G', 'C']]
         for encoder_name in ('BaseNEncoder', 'BinaryEncoder', 'OrdinalEncoder', 'OneHotEncoder'):
             with self.subTest(encoder_name=encoder_name):
                 enc = getattr(encoders, encoder_name)(drop_invariant=True)
                 transformed = enc.fit_transform(x)
-                with self.assertRaises(ValueError) as cm:
+                with self.assertRaisesRegex(ValueError, r'^Unexpected input dimension'):
                     enc.inverse_transform(transformed)
-                self.assertTrue(
-                    str(cm.exception).startswith('Unexpected input dimension'),
-                    f'{encoder_name}: expected message starting with '
-                    f"'Unexpected input dimension', got: {cm.exception!r}",
-                )

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -1002,3 +1002,26 @@ class TestEncoders(TestCase):
                 enc = getattr(encoders, encoder_name)(cols=['col1'])
                 out = enc.fit_transform(X, y)
                 self.assertTrue(out.col2[2] is None)
+
+    def test_inverse_transform_with_drop_invariant_raises_clean_error(self):
+        """inverse_transform with drop_invariant=True must raise a clear
+        ValueError, not an opaque IndexError or KeyError.
+
+        The encoders cannot reconstruct the input when invariant columns
+        have been dropped — that information is no longer available — so
+        refusing the call is correct. Issue #190 sets the bar that the
+        message starts with 'Unexpected input dimension' for every
+        encoder that supports drop_invariant.
+        """
+        x = [['A', 'B', 'C'], ['D', 'E', 'C'], ['F', 'G', 'C']]  # last col invariant
+        for encoder_name in ('BaseNEncoder', 'BinaryEncoder', 'OrdinalEncoder', 'OneHotEncoder'):
+            with self.subTest(encoder_name=encoder_name):
+                enc = getattr(encoders, encoder_name)(drop_invariant=True)
+                transformed = enc.fit_transform(x)
+                with self.assertRaises(ValueError) as cm:
+                    enc.inverse_transform(transformed)
+                self.assertTrue(
+                    str(cm.exception).startswith('Unexpected input dimension'),
+                    f'{encoder_name}: expected message starting with '
+                    f"'Unexpected input dimension', got: {cm.exception!r}",
+                )


### PR DESCRIPTION
Fixes #190

## Proposed Changes

- In `BaseNEncoder.inverse_transform` and `OneHotEncoder.inverse_transform`,
  refuse early when `self.drop_invariant and self.invariant_cols` and raise
  a clear `ValueError` whose message starts with `'Unexpected input dimension'`.
  Without that early check, `basen_to_integer` / `reverse_dummies` iterated
  the *original* mapping and crashed on missing column names with
  `IndexError: list index out of range` (BaseN, Binary, Gray) or
  `ValueError: '<col>_<level>' is not in list` (OneHot).
- Keep the post-decode dim check as a backstop for unrelated dim mismatches
  (e.g. caller passed a frame with extra columns).
- `OrdinalEncoder.inverse_transform` was already raising the right error
  before this PR — left untouched.
- New regression test
  `tests/test_encoders.py::TestEncoders::test_inverse_transform_with_drop_invariant_raises_clean_error`
  derived from the parameterised test the reporter shipped in the issue
  body. It loops over all four affected encoders and asserts the error
  message prefix.

## Why

Per the issue: "Inverse_transform should ideally handle absence of the
columns dropped because of `drop_invariant=True`. But if it is not
possible, `inverse_transform()` should at least return the correct error
message instead of just crashing."

The encoders genuinely cannot reconstruct an invariant column from
encoded data — the constant value is no longer represented anywhere — so
"refuse with a clear error" is the right semantic. This PR opts for the
second half of the maintainer's options.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/scikit-learn-contrib/category_encoders.git /tmp/repro && cd /tmp/repro
python -m venv .venv && source .venv/bin/activate
pip install -e .

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "
import category_encoders as encoders
x = [['A', 'B', 'C'], ['D', 'E', 'C'], ['F', 'G', 'C']]  # last col invariant
for name in ('BaseNEncoder', 'BinaryEncoder', 'OrdinalEncoder', 'OneHotEncoder'):
    enc = getattr(encoders, name)(drop_invariant=True)
    transformed = enc.fit_transform(x)
    try:
        enc.inverse_transform(transformed)
    except Exception as e:
        print(f'{name}: {type(e).__name__}: {e}')
"
# Expected:
#   BaseNEncoder:   IndexError: list index out of range
#   BinaryEncoder:  IndexError: list index out of range
#   OrdinalEncoder: ValueError: Unexpected input dimension 2, ...
#   OneHotEncoder:  ValueError: '2_1' is not in list

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/category_encoders.git feat/190-inverse-transform-clear-error
git checkout FETCH_HEAD
pip install -e .
python -c "
import category_encoders as encoders
x = [['A', 'B', 'C'], ['D', 'E', 'C'], ['F', 'G', 'C']]
for name in ('BaseNEncoder', 'BinaryEncoder', 'OrdinalEncoder', 'OneHotEncoder'):
    enc = getattr(encoders, name)(drop_invariant=True)
    transformed = enc.fit_transform(x)
    try:
        enc.inverse_transform(transformed)
    except Exception as e:
        print(f'{name}: {type(e).__name__}: {e}')
"
# Expected: all four raise ValueError starting with 'Unexpected input dimension ...'
```

## What I ran locally

- New test
  `tests/test_encoders.py::TestEncoders::test_inverse_transform_with_drop_invariant_raises_clean_error`:
  4 subtests pass on this branch, fail on `origin/master` (3 of 4 raise the
  wrong exception type).
- `pytest tests/test_basen.py tests/test_binary.py tests/test_one_hot.py tests/test_gray.py tests/test_ordinal.py -v` → 52 passed, 23 subtests passed.
- Full `pytest tests/`: 213 passed, 24 pre-existing failures (verified
  identical set on `origin/master` — pandas 3 / numpy 2 compat issues
  unrelated to this change), 2 skipped.
- `ruff check category_encoders/basen.py category_encoders/one_hot.py` → All checks passed.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | `drop_invariant=True` with at least one invariant column dropped | `[['A','B','C'], ['D','E','C'], ['F','G','C']]` | `ValueError: Unexpected input dimension ...` | new test, all four encoders |
| 2 | `drop_invariant=False`, valid round-trip | `[['A','B'], ['C','D']]` | inverse returns the input unchanged | existing `test_inverse_transform_missing_value` |
| 3 | `drop_invariant=True` but no actually-invariant columns | `[['A','B'], ['C','D']]` | inverse works (early-refuse only triggers when `invariant_cols` is non-empty) | existing tests for round-trip |

## Risk / blast radius

Behaviorally additive on the error path: the only change for non-drop-invariant
callers is the timing of an existing `ValueError` (now raised after `reverse_dummies`
when dim still doesn't match — same message). Drop-invariant callers that
previously crashed with `IndexError` / `'<col>' is not in list` now see
`ValueError: Unexpected input dimension ...` with a hint about
`drop_invariant`.

## Release note

```release-note
Fix: inverse_transform with drop_invariant=True now raises a clear
ValueError instead of an opaque IndexError / "X is not in list" error.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against scikit-learn-contrib/category_encoders source and the
issue's parametrised reproducer was used during development; it is the
same one a reviewer can paste verbatim.*
