### PR TITLE
docs(hashing): clarify n_components is the dimension, not bits (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+unreleased
+==========
+
+* Fix: Fixed issue#402 - clarified HashingEncoder ``n_components``
+  docstring (it is the number of output hash buckets, not bits).
+
 v.2.9.0
 =======
 

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -57,8 +57,16 @@ class HashingEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         6C12T CPU with 100,000 samples makes max_sample=16,666.
         It is not recommended to set it larger than the default value.
     n_components: int
-        how many bits to use to represent the feature. By default, we use 8 bits.
-        For high-cardinality features, consider using up-to 32 bits.
+        the number of output features (hash buckets) the encoder will produce
+        per encoded column. By default, ``n_components=8``, meaning each
+        encoded column expands to 8 hash columns named ``col_0`` … ``col_7``.
+        Note that this is the *dimension*, not the number of bits — setting
+        ``n_components=32`` produces 32 hash buckets, not 2**32. The
+        collision rate is roughly ``1 / n_components``, so for
+        high-cardinality features prefer larger values (sklearn's
+        ``FeatureHasher`` uses ``n_features=2**20`` by default for
+        comparison). See `Feature hashing on Wikipedia
+        <https://en.wikipedia.org/wiki/Feature_hashing>`_ and issue #402.
     process_creation_method: string
         either "fork", "spawn" or "forkserver" (availability depends on your
         platform). See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods

--- a/category_encoders/hashing.py
+++ b/category_encoders/hashing.py
@@ -57,16 +57,12 @@ class HashingEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         6C12T CPU with 100,000 samples makes max_sample=16,666.
         It is not recommended to set it larger than the default value.
     n_components: int
-        the number of output features (hash buckets) the encoder will produce
-        per encoded column. By default, ``n_components=8``, meaning each
-        encoded column expands to 8 hash columns named ``col_0`` … ``col_7``.
-        Note that this is the *dimension*, not the number of bits — setting
-        ``n_components=32`` produces 32 hash buckets, not 2**32. The
-        collision rate is roughly ``1 / n_components``, so for
-        high-cardinality features prefer larger values (sklearn's
-        ``FeatureHasher`` uses ``n_features=2**20`` by default for
-        comparison). See `Feature hashing on Wikipedia
-        <https://en.wikipedia.org/wiki/Feature_hashing>`_ and issue #402.
+        the number of output features (hash buckets) per encoded column.
+        Defaults to 8. This is the *dimension*, not a bit count —
+        ``n_components=32`` produces 32 buckets, not 2**32. The collision
+        rate is roughly ``1 / n_components``; prefer larger values for
+        high-cardinality features. See `Feature hashing on Wikipedia
+        <https://en.wikipedia.org/wiki/Feature_hashing>`_.
     process_creation_method: string
         either "fork", "spawn" or "forkserver" (availability depends on your
         platform). See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods


### PR DESCRIPTION
Fixes #402

## Proposed Changes

- Rewrite the `n_components` docstring on `HashingEncoder` to state
  that it is the number of output hash buckets (the *dimension*), not
  the number of bits.
- Add a pointer to feature hashing references and to sklearn's
  `FeatureHasher` for users coming from that library.

## Why

Per the issue, the previous wording ("how many bits to use to represent
the feature") suggested `n_components=8` would yield 2**8 distinct
encoded values. The actual behaviour is the standard feature-hashing
trick: the encoder maps each value to one of `n_components` buckets, so
the collision rate is `~1/n_components`. The maintainer
[downgraded the bug to a documentation issue](https://github.com/scikit-learn-contrib/category_encoders/issues/402#issuecomment-1537209019)
on that basis and asked for the doc to be fixed.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
git clone https://github.com/scikit-learn-contrib/category_encoders.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/master) ---
git checkout origin/master
python -c "
import inspect
from category_encoders import HashingEncoder
print(inspect.getdoc(HashingEncoder).split('n_components')[1].split('process_creation_method')[0])
"
# Expected: docstring snippet says 'how many bits to use to represent the feature'.

# --- AFTER (this PR) ---
git fetch https://github.com/jbbqqf/category_encoders.git feat/402-doc-hashing-n-components
git checkout FETCH_HEAD
python -c "
import inspect
from category_encoders import HashingEncoder
print(inspect.getdoc(HashingEncoder).split('n_components')[1].split('process_creation_method')[0])
"
# Expected: docstring states it is the number of output hash buckets, with collision-rate guidance.
```

## What I ran locally

- `ruff check category_encoders/hashing.py` → All checks passed (the
  numpydoc docstring rules pass).
- No code path is touched, so no test changes are needed; the
  `tests/test_hashing.py` suite remains untouched and green.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Behavior unchanged; only docstring edited | n/a | tests/test_hashing.py still green | existing suite |

## Risk / blast radius

Doc-only change.

## Release note

```release-note
Fix: clarified HashingEncoder ``n_components`` docstring (it is the
number of output hash buckets, not bits).
```

---

*PR drafted with assistance from Claude Code. The change was reviewed
manually against the issue thread and the maintainer's expressed
preference to downgrade the original bug report to a documentation
fix.*
