### PR TITLE
Backfill unreleased changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 unreleased
 ==========
 
+* Feat: Added issue#291 - ``index_start`` parameter on OrdinalEncoder for
+  zero-indexed labels.
+* Feat: Added issue#456 - ``cols="all"`` encodes every column regardless of
+  dtype (useful inside sklearn ``ColumnTransformer``).
 * Fix: Fixed issue#168 - encoders now raise ValueError on unrecognised
   handle_missing/handle_unknown string values instead of silently treating
   them as the default.
@@ -15,6 +19,9 @@ unreleased
   docstring (it is the number of output hash buckets, not bits).
 * Fix: Fixed issue#442 - encoders now honor return_df=False even when
   the resolved column list is empty (e.g. on a numeric-only DataFrame).
+* Fix: Fixed issue#457 - CountEncoder with ``normalize=True`` and
+  ``drop_invariant=True`` no longer drops all output columns.
+* Docs: Spelling fixes throughout the codebase (#464).
 
 v.2.9.0
 =======


### PR DESCRIPTION
## Summary

The ``unreleased`` section of ``CHANGELOG.md`` was missing entries for several PRs that landed on master since v2.9.0. This backfills them.

## Commits since v2.9.0 vs. CHANGELOG

Already present (the five recently-merged jbbqqf PRs):
- #474 — handle_missing/handle_unknown validation (#168)
- #475 — return_df honored on empty cols (#442)
- #476 — clean inverse_transform error with drop_invariant (#190)
- #477 — n_components docstring (#402)
- #478 — sigma multiplicative docstring (#333)

Added by this PR:
- ``Feat`` — ``index_start`` on OrdinalEncoder (#479, fixes #291)
- ``Feat`` — ``cols="all"`` to encode every column regardless of dtype (#470, fixes #456)
- ``Fix`` — CountEncoder with ``normalize=True`` + ``drop_invariant=True`` (#469, fixes #457)
- ``Docs`` — spelling fixes (#464)

Intentionally skipped (not user-facing):
- #471, #473 — JOSS paper updates

## Test plan

- [ ] No code change; CHANGELOG.md only.