### PR TITLE
Fix OneHotEncoder handle_missing='value' to encode missing values as zeros (fixes #400)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ unreleased
   the resolved column list is empty (e.g. on a numeric-only DataFrame).
 * Fix: Fixed issue#457 - CountEncoder with ``normalize=True`` and
   ``drop_invariant=True`` no longer drops all output columns.
+* Fix: Fixed issue#400 - OneHotEncoder with ``handle_missing='value'`` now
+  encodes a missing value seen during fit as 0 in every dummy column (as the
+  documentation states), instead of adding an extra dummy column for it.
 * Docs: Spelling fixes throughout the codebase (#464).
 
 v.2.9.0

--- a/category_encoders/one_hot.py
+++ b/category_encoders/one_hot.py
@@ -140,7 +140,7 @@ class OneHotEncoder( util.UnsupervisedTransformerMixin,util.BaseEncoder):
         oe_missing_strat = {
             'error': 'error',
             'return_nan': 'return_nan',
-            'value': 'value',
+            'value': 'return_nan',
             'indicator': 'return_nan',
             'ignore': 'return_nan',
         }[self.handle_missing]

--- a/tests/test_one_hot.py
+++ b/tests/test_one_hot.py
@@ -216,6 +216,40 @@ class TestOneHotEncoder(TestCase):
         pd.testing.assert_frame_equal(expected_result, result)
         pd.testing.assert_frame_equal(expected_mapping, encoder.category_mapping[0]['mapping'])
 
+    def test_handle_missing_value(self):
+        """Test that a missing value is encoded as 0 in every dummy column.
+
+        Regression test for issue #400: with ``handle_missing='value'`` a
+        missing value present in the training data must be encoded as zeros in
+        every dummy column, the same as ``handle_missing='ignore'``. It must not
+        get its own dummy column, which would contradict the documented
+        behaviour ("'value' will encode a missing value as 0 in every dummy
+        column").
+        """
+        train = pd.DataFrame({'city': ['chicago', 'geneva', np.nan]})
+        expected_result = pd.DataFrame({'city_1': [1, 0, 0], 'city_2': [0, 1, 0]})
+
+        encoder = encoders.OneHotEncoder(handle_missing='value')
+        result = encoder.fit_transform(train)
+
+        pd.testing.assert_frame_equal(expected_result, result)
+
+        # the missing row (-2) and the unknown row (-1) are both all zeros;
+        # no extra column is created for the missing category
+        expected_mapping = pd.DataFrame(
+            [
+                [1, 0],
+                [0, 1],
+                [0, 0],
+                [0, 0],
+            ],
+            columns=['city_1', 'city_2'],
+            index=[1, 2, -1, -2],
+        )
+        pd.testing.assert_frame_equal(
+            expected_mapping, encoder.category_mapping[0]['mapping']
+        )
+
     def test_handle_missing_indicator(self):
         """Test that missing values are encoded with an indicator column."""
         with self.subTest("Should create a column if NaN in training set"):


### PR DESCRIPTION
## Summary

Fixes #400.

With `handle_missing='value'` (the default), a missing value present in the **training** data was given its own dummy column instead of being encoded as `0` in every dummy column. This contradicts the documented behaviour ("`'value'` will encode a missing value as 0 in every dummy column").

```python
from category_encoders import OneHotEncoder
import pandas as pd

data = pd.DataFrame([('foo', 1), ('bar', 2), (None, 6)], columns=['c1', 'c2'])
OneHotEncoder(handle_missing='value').fit_transform(data)
```

Before this PR the `None` row produced an extra `c1_3` column; after it, the missing row is `0` across `c1_1`/`c1_2`, matching the docs and the `'ignore'` strategy.

## Root cause

`OneHotEncoder._fit` maps `handle_missing='value'` to the ordinal strategy `'value'`. When a NaN is present during `fit`, the internal `OrdinalEncoder` assigns it a positive code, which then survives the `values[values > 0]` filter in `generate_mapping` and becomes its own dummy column. (When NaN appears only at transform time it was already handled correctly via the `base_df.loc[-2] = 0` row.)

## Fix

Map the `'value'` strategy to the ordinal `'return_nan'` path (NaN -> `-2`), exactly as `'ignore'` already does. The missing code is then dropped from the columns and encoded as all-zeros through the existing `base_df.loc[-2] = 0` row. Other modes (`indicator`, `return_nan`, `error`, `ignore`) are unchanged.

## Tests

- Added `test_handle_missing_value` covering the issue's reproduction (both the transformed result and the mapping).
- Full `tests/test_one_hot.py` passes locally (17 passed, 12 subtests) and `ruff check` is clean. No existing test needed changing — the inverse-transform round-trips still hold.

## A note for maintainers

In the issue thread you mentioned the `value` vs `ignore` naming is a little ambiguous. This PR keeps both options and only makes `value` match its documented behaviour (so `value` and `ignore` now coincide for missing values). Happy to instead update the docs, deprecate/rename, or take whatever direction you prefer.

_Prepared with AI assistance and verified locally._
