### PR TITLE
Correct LICENSE copyright holder to Helton Labs LLC (JOSS #483)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Helton Tech, LLC
+Copyright (c) 2015, Helton Labs LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Addresses the JOSS review question in #483 (review thread openjournals/joss-reviews#10645).

The reviewer asked us to verify the copyright holder named in `LICENSE.md`. It is corrected from `Helton Tech, LLC` to the current entity, `Helton Labs LLC`.

Closes #483
