### PR TITLE
Fix examples/encoding_examples.py crash on modern dependencies (JOSS #486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ unreleased
   the resolved column list is empty (e.g. on a numeric-only DataFrame).
 * Fix: Fixed issue#457 - CountEncoder with ``normalize=True`` and
   ``drop_invariant=True`` no longer drops all output columns.
+* Fix: Fixed issue#486 - GLMMEncoder regression path used positional
+  ``Series[0]`` access that raised ``KeyError`` on recent pandas; use
+  ``.iloc[0]`` instead. Also fixed the bundled ``examples`` script
+  (removed the ``LogisticRegression(multi_class=...)`` argument removed in
+  scikit-learn 1.9).
 * Docs: Spelling fixes throughout the codebase (#464).
 
 v.2.9.0

--- a/category_encoders/glmm.py
+++ b/category_encoders/glmm.py
@@ -218,7 +218,7 @@ class GLMMEncoder( util.SupervisedTransformerMixin ,util.BaseEncoder):
                             md = smf.mixedlm('target ~ 1', data, groups=data['feature']).fit()
                             tmp = {}
                             for key, value in md.random_effects.items():
-                                tmp[key] = value[0]
+                                tmp[key] = value.iloc[0]
                             estimate = pd.Series(tmp)
                 except np.linalg.LinAlgError:
                     # Singular matrix -> just return all zeros

--- a/examples/encoding_examples.py
+++ b/examples/encoding_examples.py
@@ -1,5 +1,5 @@
 """
-Tested to work with scikit-learn 0.20.2
+Tested to work with scikit-learn >= 1.6.0
 """
 
 import gc
@@ -60,7 +60,7 @@ def main(loader, name):
     X, y, mapping = loader()
 
     clf = linear_model.LogisticRegression(
-        solver='lbfgs', multi_class='auto', max_iter=200, random_state=0
+        solver='lbfgs', max_iter=200, random_state=0
     )
 
     # try each encoding method available, which works on multiclass problems


### PR DESCRIPTION
Fixes the crash reported in #486 (JOSS review thread openjournals/joss-reviews#10645).

`examples/encoding_examples.py` failed immediately on a fresh install because:

- `LogisticRegression(multi_class='auto', ...)` — the `multi_class` argument was deprecated in scikit-learn 1.7 and removed in 1.9; the package requires `scikit-learn >= 1.6`, so any current install crashes with `TypeError`. Removed the argument.
- The header comment claimed "Tested to work with scikit-learn 0.20.2". Updated to `>= 1.6.0`.

While running the example to completion, it surfaced a second latent bug: `GLMMEncoder`'s regression path read random effects with positional `Series[0]`, which raises `KeyError` on recent pandas. Changed to `.iloc[0]`. With both fixes the example now runs end-to-end.

Closes #486
