### PR TITLE
Replace removed load_boston in README examples (JOSS #487)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,16 @@ There are two types of encoders: unsupervised and supervised. An unsupervised ex
 ```python
 from category_encoders import *
 import pandas as pd
-from sklearn.datasets import load_boston
 
-# prepare some data
-bunch = load_boston()
-y = bunch.target
-X = pd.DataFrame(bunch.data, columns=bunch.feature_names)
+# prepare some data with categorical features
+X = pd.DataFrame({
+    'gender': ['male', 'female', 'female', 'male', 'female'],
+    'country': ['US', 'UK', 'US', 'CA', 'UK'],
+    'age': [25, 32, 47, 51, 38],
+})
 
 # use binary encoding to encode two categorical features
-enc = BinaryEncoder(cols=['CHAS', 'RAD']).fit(X)
+enc = BinaryEncoder(cols=['gender', 'country']).fit(X)
 
 # transform the dataset
 numeric_dataset = enc.transform(X)
@@ -102,17 +103,20 @@ And a supervised example:
 ```python
 from category_encoders import *
 import pandas as pd
-from sklearn.datasets import load_boston
 
-# prepare some data
-bunch = load_boston()
-y_train = bunch.target[0:250]
-y_test = bunch.target[250:506]
-X_train = pd.DataFrame(bunch.data[0:250], columns=bunch.feature_names)
-X_test = pd.DataFrame(bunch.data[250:506], columns=bunch.feature_names)
+# prepare some training and test data with categorical features and a target
+X_train = pd.DataFrame({
+    'gender': ['male', 'female', 'female', 'male'],
+    'country': ['US', 'UK', 'US', 'CA'],
+})
+y_train = pd.Series([1, 0, 1, 0])
+X_test = pd.DataFrame({
+    'gender': ['female', 'male'],
+    'country': ['UK', 'US'],
+})
 
 # use target encoding to encode two categorical features
-enc = TargetEncoder(cols=['CHAS', 'RAD'])
+enc = TargetEncoder(cols=['gender', 'country'])
 
 # transform the datasets
 training_numeric_dataset = enc.fit_transform(X_train, y_train)


### PR DESCRIPTION
Fixes the broken README quickstart examples reported in #487 (JOSS review thread openjournals/joss-reviews#10645).

Both code examples imported `sklearn.datasets.load_boston`, which was removed from scikit-learn in 1.2. Since the package requires `scikit-learn >= 1.6`, the examples failed on import.

Replaced both with small self-contained synthetic DataFrames that have real categorical columns (`gender`, `country`). These run as-is and demonstrate the encoders more directly than the numeric Boston features did. Verified both snippets execute.

Closes #487
