### PR TITLE
Fix NotFittedError under transform_output='pandas' (JOSS #488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ unreleased
   the resolved column list is empty (e.g. on a numeric-only DataFrame).
 * Fix: Fixed issue#457 - CountEncoder with ``normalize=True`` and
   ``drop_invariant=True`` no longer drops all output columns.
+* Fix: Fixed issue#488 - encoders no longer raise ``NotFittedError`` during
+  ``fit``/``fit_transform`` when scikit-learn's ``transform_output='pandas'``
+  is configured globally or via a ``ColumnTransformer``.
 * Docs: Spelling fixes throughout the codebase (#464).
 
 v.2.9.0

--- a/category_encoders/utils.py
+++ b/category_encoders/utils.py
@@ -487,7 +487,16 @@ class BaseEncoder(BaseEstimator):
 
         # for finding invariant columns transform without y (as is done on the test set)
         self.feature_names_out_ = None  # Issue#437
-        X_transformed = self.transform(X, override_return_df=True)
+        # bypass set_output wrapping here; feature_names_out_ is not ready yet
+        prev_output_config = getattr(self, '_sklearn_output_config', None)
+        self._sklearn_output_config = {'transform': 'default'}
+        try:
+            X_transformed = self.transform(X, override_return_df=True)
+        finally:
+            if prev_output_config is None:
+                del self._sklearn_output_config
+            else:
+                self._sklearn_output_config = prev_output_config
         self.feature_names_out_ = X_transformed.columns.to_numpy()
 
         # drop all output columns with 0 variance.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -193,3 +193,24 @@ class TestBaseEncoder(TestCase):
         self.encoder.fit_transform(df.iloc[:1])
         out = self.encoder.fit_transform(df.rename(columns={'C1': 'X1', 'C2': 'X2'}))
         self.assertTrue(list(out.columns) == ['X1', 'X2'])
+
+    @pytest.mark.skipif(Version(skl_version) < Version('1.2'), reason='requires sklearn > 1.2')
+    def test_global_transform_output_pandas(self):
+        """Encoders must fit under a global transform_output='pandas' config (Issue#488)."""
+        import category_encoders as encoders
+        from sklearn import config_context
+        from sklearn.compose import ColumnTransformer
+
+        X = pd.DataFrame({'color': ['red', 'blue', 'green', 'red']})
+        y = [1, 0, 1, 0]
+        with config_context(transform_output='pandas'):
+            out = encoders.OrdinalEncoder().fit_transform(X, y)
+            self.assertIsInstance(out, pd.DataFrame)
+
+            ct = ColumnTransformer(
+                [('enc', encoders.TargetEncoder(cols=['color']), ['color'])],
+                remainder='passthrough',
+            )
+            ct.set_output(transform='pandas')
+            ct_out = ct.fit_transform(X, y)
+            self.assertIsInstance(ct_out, pd.DataFrame)


### PR DESCRIPTION
Fixes the `NotFittedError` crash reported in #488 (JOSS review thread openjournals/joss-reviews#10645).

**Problem.** With scikit-learn's `set_config(transform_output='pandas')` (globally, or per-estimator inside a `ColumnTransformer`), every encoder crashed during `fit`/`fit_transform`:

```
sklearn.exceptions.NotFittedError: Estimator has to be fitted to return feature names.
```

**Root cause.** During `fit`, `BaseEncoder` discovers output column names with an internal `self.transform(X)` call while `feature_names_out_` is still `None`. sklearn's `set_output` wrapper intercepts that call and invokes `get_feature_names_out()`, which raises because the encoder isn't fitted yet.

**Fix.** Temporarily force this estimator's output config to `'default'` for that one internal call, then restore it. This covers both the global config and the per-estimator config a `ColumnTransformer` sets (the per-estimator config takes precedence over `config_context`, so a context manager alone is insufficient).

Adds a regression test mirroring the reported cases (global `set_config` + `ColumnTransformer` with `remainder='passthrough'`). This repairs the cluster of `NotFittedError` test failures the reviewer observed when running `pytest tests/`.

Closes #488
