### PR TITLE
Sync __version__ with pyproject.toml (2.9.0) (JOSS review)

### DIFF
--- a/category_encoders/__init__.py
+++ b/category_encoders/__init__.py
@@ -27,7 +27,7 @@ from category_encoders.sum_coding import SumEncoder
 from category_encoders.target_encoder import TargetEncoder
 from category_encoders.woe import WOEEncoder
 
-__version__ = '2.8.1'
+__version__ = '2.9.0'
 
 __author__ = 'willmcginnis', 'cmougan', 'paulwestenthanner'
 


### PR DESCRIPTION
Raised in the JOSS review (openjournals/joss-reviews#10645): `category_encoders/__init__.py` declared `__version__ = '2.8.1'` while `pyproject.toml` is on `2.9.0`. Aligns the package `__version__` with the packaged version.
