### PR TITLE
Add citation metadata and prep 2.10.0 release (JOSS review)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,50 @@
+{
+  "title": "category_encoders: a scikit-learn-contrib package of transformers for encoding categorical data",
+  "description": "A set of scikit-learn-style transformers for encoding categorical variables into numeric with different techniques.",
+  "upload_type": "software",
+  "license": "BSD-3-Clause",
+  "creators": [
+    {
+      "name": "McGinnis, William D",
+      "orcid": "0000-0002-3009-9465",
+      "affiliation": "Scale Venture Partners"
+    },
+    {
+      "name": "Siu, Chapman",
+      "orcid": "0000-0002-2089-3796",
+      "affiliation": "Suncorp Group Ltd."
+    },
+    {
+      "name": "S, Andre",
+      "orcid": "0000-0001-5104-0465",
+      "affiliation": "Jungle AI"
+    },
+    {
+      "name": "Huang, Hanyu",
+      "orcid": "0000-0001-8503-1014",
+      "affiliation": "Tencent, Inc."
+    },
+    {
+      "name": "Motl, Jan",
+      "orcid": "0000-0002-0388-3190",
+      "affiliation": "Czech Technical University in Prague"
+    },
+    {
+      "name": "Westenthanner, Kaspar Paul",
+      "orcid": "0009-0007-4284-3953",
+      "affiliation": "Atruvia"
+    },
+    {
+      "name": "Castaldo, Jonathan",
+      "orcid": "0009-0001-2553-5920",
+      "affiliation": "Meta, Inc."
+    }
+  ],
+  "keywords": [
+    "machine learning",
+    "python",
+    "scikit-learn",
+    "categorical encoding",
+    "feature engineering"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-unreleased
-==========
+v.2.10.0
+========
 
+* Release: JOSS review release. Consolidated citation metadata with the JOSS
+  paper via new ``.zenodo.json`` and ``CITATION.cff`` files, and pointed the
+  README DOI badge at the Zenodo concept DOI (always resolves to the latest
+  version).
 * Feat: Added issue#291 - ``index_start`` parameter on OrdinalEncoder for
   zero-indexed labels.
 * Feat: Added issue#456 - ``cols="all"`` encodes every column regardless of

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,45 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using these metadata."
+title: "category_encoders: a scikit-learn-contrib package of transformers for encoding categorical data"
+abstract: "A set of scikit-learn-style transformers for encoding categorical variables into numeric with different techniques."
+type: software
+authors:
+  - family-names: McGinnis
+    given-names: "William D"
+    orcid: "https://orcid.org/0000-0002-3009-9465"
+    affiliation: "Scale Venture Partners"
+  - family-names: Siu
+    given-names: Chapman
+    orcid: "https://orcid.org/0000-0002-2089-3796"
+    affiliation: "Suncorp Group Ltd."
+  - family-names: S
+    given-names: Andre
+    orcid: "https://orcid.org/0000-0001-5104-0465"
+    affiliation: "Jungle AI"
+  - family-names: Huang
+    given-names: Hanyu
+    orcid: "https://orcid.org/0000-0001-8503-1014"
+    affiliation: "Tencent, Inc."
+  - family-names: Motl
+    given-names: Jan
+    orcid: "https://orcid.org/0000-0002-0388-3190"
+    affiliation: "Czech Technical University in Prague"
+  - family-names: Westenthanner
+    given-names: "Kaspar Paul"
+    orcid: "https://orcid.org/0009-0007-4284-3953"
+    affiliation: "Atruvia"
+  - family-names: Castaldo
+    given-names: Jonathan
+    orcid: "https://orcid.org/0009-0001-2553-5920"
+    affiliation: "Meta, Inc."
+version: 2.10.0
+doi: 10.5281/zenodo.1157109
+license: BSD-3-Clause
+repository-code: "https://github.com/scikit-learn-contrib/category_encoders"
+url: "http://contrib.scikit-learn.org/category_encoders/"
+keywords:
+  - machine learning
+  - python
+  - scikit-learn
+  - categorical encoding
+  - feature engineering

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Categorical Encoding Methods
 [![Downloads](https://pepy.tech/badge/category-encoders)](https://pepy.tech/project/category-encoders)
 [![Downloads](https://pepy.tech/badge/category-encoders/month)](https://pepy.tech/project/category-encoders)
 ![Test Suite and Linting](https://github.com/scikit-learn-contrib/category_encoders/workflows/Test%20Suite%20and%20Linting/badge.svg)
-[![DOI](https://zenodo.org/badge/47077067.svg)](https://zenodo.org/badge/latestdoi/47077067)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1157109.svg)](https://doi.org/10.5281/zenodo.1157109)
 
 A set of scikit-learn-style transformers for encoding categorical 
 variables into numeric by means of different techniques.

--- a/category_encoders/__init__.py
+++ b/category_encoders/__init__.py
@@ -27,7 +27,7 @@ from category_encoders.sum_coding import SumEncoder
 from category_encoders.target_encoder import TargetEncoder
 from category_encoders.woe import WOEEncoder
 
-__version__ = '2.9.0'
+__version__ = '2.10.0'
 
 __author__ = 'willmcginnis', 'cmougan', 'paulwestenthanner'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "category_encoders"
-version = "2.9.0"
+version = "2.10.0"
 description = "A package for encoding categorical variables for machine learning"
 authors = ["PaulWestenthanner <paul@westenthanner.dev>"]
 license = "BSD-3"


### PR DESCRIPTION
Addresses the JOSS editor's remaining pre-acceptance items (openjournals/joss-reviews#10645): the Zenodo↔paper author discrepancy, the stale DOI badge, and preparing a fresh release that includes all JOSS-review PRs.

## What this does

**Consolidate authorship metadata with the paper.** The repo had no `.zenodo.json` or `CITATION.cff`, so the existing Zenodo record (v1.2.6, Jan 2018, `10.5281/zenodo.1157110`) listed raw GitHub handles (`hbghhy`, `andrethrill`, `Wenwu Tao`, `Cameron Davison`, `Nicholas Bollweg`) rather than the paper's authors. This PR adds both files with a creator list that **exactly matches the seven `paper.md` authors** — names, ORCIDs, and affiliations. The next Zenodo deposit will pick these up.

**Fix the DOI badge.** The README badge used the legacy `zenodo.org/badge/latestdoi/47077067` form, which currently resolves to the 2018 v1.2.6 record. It now points at the **concept DOI** `10.5281/zenodo.1157109`, which always resolves to the latest version.

**Prepare the 2.10.0 release.** Bumps `2.9.0 → 2.10.0` (`pyproject.toml`, `__init__.py`) and cuts the CHANGELOG `unreleased` block into a `v.2.10.0` section. The last release (2.9.0, Nov 2025) predates every JOSS-review merge; 2.10.0 collects PRs #489–#494 plus the other post-2.9.0 work.

## Author / affiliation list (Zenodo + CITATION.cff, matching paper.md)

| Author | ORCID | Affiliation |
|---|---|---|
| William D McGinnis | 0000-0002-3009-9465 | Scale Venture Partners |
| Chapman Siu | 0000-0002-2089-3796 | Suncorp Group Ltd. |
| Andre S | 0000-0001-5104-0465 | Jungle AI |
| Hanyu Huang | 0000-0001-8503-1014 | Tencent, Inc. |
| Jan Motl | 0000-0002-0388-3190 | Czech Technical University in Prague |
| Kaspar Paul Westenthanner | 0009-0007-4284-3953 | Atruvia |
| Jonathan Castaldo | 0009-0001-2553-5920 | Meta, Inc. |

Note: `paper.md` lists McGinnis with two affiliations (Scale Venture Partners; Helton Labs, LLC); Zenodo/CFF take a single string, so the first is used.

## Follow-up (outside this PR)
- After merge, cut the **GitHub 2.10.0 release** → this triggers a new Zenodo deposit that supersedes the 2018 record and updates the concept-DOI badge.
- Confirm the GitHub↔Zenodo webhook is still enabled on the repo so the deposit fires.