### PR TITLE
Fix GrayEncoder.inverse_transform to recover the original categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+unreleased
+==========
+
+* Fix: ``GrayEncoder.inverse_transform`` now recovers the original categories.
+  Previously it inherited the positional base-N decoder from ``BaseNEncoder``,
+  which cannot invert a Gray code (consecutive code words differ by a single
+  bit and are not positional), so it returned the wrong categories.
+
 v.2.10.0
 ========
 

--- a/category_encoders/gray.py
+++ b/category_encoders/gray.py
@@ -1,8 +1,10 @@
 """Gray encoding."""
 
+import re
 from functools import partialmethod
 from typing import List
 
+import numpy as np
 import pandas as pd
 
 from category_encoders import utils
@@ -136,3 +138,51 @@ class GrayEncoder(BaseNEncoder):
             gray_encoding = pd.concat([gray_encoding, map_null])
             gray_mapping.append({'col': col, 'mapping': gray_encoding})
         self.mapping = gray_mapping
+
+    def basen_to_integer(self, X, cols, base):
+        """Convert Gray-encoded columns back to their ordinal integers.
+
+        The positional base-N decoding used by :class:`BaseNEncoder` cannot invert
+        a Gray code: consecutive code words differ only by a single bit and do not
+        represent a positional value, so the inherited decoder recovers the wrong
+        category. Instead, every Gray code word is looked up in the fitted mapping
+        to recover the original ordinal value, mirroring the table lookup used in
+        the forward transform.
+
+        Parameters
+        ----------
+        X : DataFrame
+            encoded data
+        cols : list-like
+            Column names in the DataFrame that were encoded
+        base : int
+            The base of the transform. Unused, kept for signature compatibility
+            with :meth:`BaseNEncoder.basen_to_integer`.
+
+        Returns
+        -------
+        numerical: DataFrame
+        """
+        out_cols = X.columns.tolist()
+
+        for col in cols:
+            col_list = [
+                col0 for col0 in out_cols if re.match(re.escape(str(col)) + '_\\d+', str(col0))
+            ]
+            insert_at = out_cols.index(col_list[0])
+
+            col_mapping = next(m['mapping'] for m in self.mapping if m['col'] == col)
+            # forward encoding is a table lookup, so invert it the same way:
+            # map each Gray code word back to its ordinal value.
+            code_word_to_value = {}
+            for ordinal_value, code_word in zip(
+                col_mapping.index, col_mapping.to_numpy(), strict=False
+            ):
+                code_word_to_value.setdefault(tuple(code_word), ordinal_value)
+            decoded = [code_word_to_value.get(tuple(row), np.nan) for row in X[col_list].to_numpy()]
+
+            X.insert(insert_at, col, decoded)
+            X = X.drop(col_list, axis=1)
+            out_cols = X.columns.tolist()
+
+        return X

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -329,7 +329,13 @@ class TestEncoders(TestCase):
         X_t = th.create_dataset(n_rows=50, has_missing=False)
         cols = ['underscore', 'none', 'categorical', 'categorical_int']
 
-        for encoder_name in ['BaseNEncoder', 'BinaryEncoder', 'OneHotEncoder', 'OrdinalEncoder']:
+        for encoder_name in [
+            'BaseNEncoder',
+            'BinaryEncoder',
+            'GrayEncoder',
+            'OneHotEncoder',
+            'OrdinalEncoder',
+        ]:
             with self.subTest(encoder_name=encoder_name):
                 # simple run
                 enc = getattr(encoders, encoder_name)(verbose=1, cols=cols)

--- a/tests/test_gray.py
+++ b/tests/test_gray.py
@@ -16,6 +16,34 @@ class TestGrayEncoder(TestCase):
         expected = pd.DataFrame([[1, 1], [1, 1], [0, 1]], columns=['0_0', '0_1'])
         pd.testing.assert_frame_equal(out, expected)
 
+    def test_inverse_transform_round_trip(self):
+        """inverse_transform should recover the original categories.
+
+        Regression test: the decoder inherited from BaseNEncoder treated the Gray
+        code words as positional binary numbers, so it recovered the wrong
+        categories (e.g. ['a', 'c', 'b', ...] instead of ['a', 'b', 'c', ...]).
+        """
+        X = pd.DataFrame({'cat': list('abcdefg'), 'other': range(7)})
+        enc = encoders.GrayEncoder(cols=['cat'])
+        transformed = enc.fit_transform(X)
+        inverse = enc.inverse_transform(transformed)
+        pd.testing.assert_frame_equal(inverse, X, check_dtype=False)
+
+    def test_inverse_transform_multiple_columns(self):
+        """inverse_transform should recover all encoded columns independently."""
+        X = pd.DataFrame({'a': list('abcabc'), 'b': list('wxyzwx')})
+        enc = encoders.GrayEncoder(cols=['a', 'b'])
+        inverse = enc.inverse_transform(enc.fit_transform(X))
+        pd.testing.assert_frame_equal(inverse, X, check_dtype=False)
+
+    def test_inverse_transform_numpy(self):
+        """inverse_transform should round-trip numpy input with return_df=False."""
+        arr = np.array([['A'], ['B'], ['B'], ['C'], ['D']])
+        enc = encoders.GrayEncoder(return_df=False)
+        enc.fit(arr)
+        decoded = enc.inverse_transform(enc.transform(arr))
+        self.assertTrue(np.array_equal(arr, decoded))
+
     def test_gray_mapping(self):
         """Test the GrayEncoder mapping."""
         train_data = pd.DataFrame()


### PR DESCRIPTION
Fixes #498.

**What**

`GrayEncoder.inverse_transform` returned the wrong categories. Round-tripping `['a', 'b', 'c', 'd', 'e', 'f', 'g']` gave `['a', 'c', 'b', 'f', 'g', 'e', 'd']`.

**Why**

`GrayEncoder` inherited `inverse_transform` / `basen_to_integer` from `BaseNEncoder`, which decodes each code word as a *positional* base-N integer. Gray code words differ by a single bit and are not positional, so the inherited decoder maps them to the wrong ordinal values.

**How**

Override `basen_to_integer` in `GrayEncoder` to invert the encoding via a reverse lookup of the fitted mapping, mirroring the table lookup used by the forward transform. `fit_transform` / `inverse_transform` now round-trip correctly for DataFrame and numpy inputs, single and multiple columns, with unknown code words mapped to `NaN` (matching `BaseNEncoder`).

**Tests**

Added regression tests in `tests/test_gray.py` (round-trip, multiple columns, numpy + `return_df=False`) and included `GrayEncoder` in the shared `test_inverse_transform` round-trip test in `tests/test_encoders.py`. On the locked env (pandas 2.3.3 / scikit-learn 1.7.2) the full suite is green — `225 passed, 2 skipped, 1086 subtests`. Added a `CHANGELOG.md` entry.
